### PR TITLE
fix: Add missing event listener for mobile customer navigation

### DIFF
--- a/app.js
+++ b/app.js
@@ -1751,6 +1751,7 @@ if (document.getElementById('mobile-nav-dashboard')) document.getElementById('mo
     if (dashboard) dashboard.renderDashboard();
 });
 if (document.getElementById('mobile-nav-company')) document.getElementById('mobile-nav-company').addEventListener('click', () => showSection('company'));
+if (document.getElementById('mobile-nav-customers')) document.getElementById('mobile-nav-customers').addEventListener('click', () => showSection('customers'));
 if (document.getElementById('mobile-nav-donation')) document.getElementById('mobile-nav-donation').addEventListener('click', () => showSection('donation'));
 if (document.getElementById('process-order-btn')) document.getElementById('process-order-btn').addEventListener('click', openPaymentProcess);
 if (document.getElementById('clear-order-btn')) document.getElementById('clear-order-btn').addEventListener('click', () => {


### PR DESCRIPTION
The event listener for the mobile customer navigation button was missing in app.js, causing the button to be unresponsive on mobile devices. This change adds the missing event listener to fix the issue.