### PR TITLE
Fix: Standardize product card styles in POS

### DIFF
--- a/app.js
+++ b/app.js
@@ -831,9 +831,9 @@ const renderMenu = async (filterCategoryId = null) => {
                 stockInfo = `<div class="stock-info no-stock-label">No llevado</div>`;
             }
             menuItemDiv.innerHTML = `
-                        <img src="${item.image || defaultPlaceholder}" alt="${item.name}" onerror="this.onerror=null;this.src='${defaultPlaceholder}';">
-                        <h3>${item.name}</h3>
-                        <p>$${item.price.toFixed(2)}</p>
+                        <img class="menu-item-image" src="${item.image || defaultPlaceholder}" alt="${item.name}" onerror="this.onerror=null;this.src='${defaultPlaceholder}';">
+                        <h3 class="menu-item-name">${item.name}</h3>
+                        <p class="menu-item-price">$${item.price.toFixed(2)}</p>
                         ${stockInfo}
                     `;
             // Permitir agregar si: no lleva control O (lleva control y tiene stock)


### PR DESCRIPTION
Adds the correct CSS classes to dynamically generated product items in the Point of Sale view.

The `menu-item-image`, `menu-item-name`, and `menu-item-price` classes were missing from the elements created in the `renderMenu` function in `app.js`. This caused product images to render at their original size, leading to inconsistent card heights and a broken layout.

This change applies the necessary classes to ensure all product cards are styled uniformly.