### PR TITLE
fix(scanner): Move scanner modal to global scope

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,22 +85,6 @@
                     <div id="category-filters" class="category-filters">
                     </div>
                     <button id="scan-barcode-btn" class="btn btn-scan">📷 Escanear Producto</button>
-                    <div id="scanner-modal" class="modal hidden">
-                        <div class="modal-content">
-                            <h2 class="modal-title">Escaneando...</h2>
-
-                            <div id="scanner-controls" class="form-group" style="display: none; margin-bottom: 1rem;">
-                                <label for="camera-select" class="form-label">Seleccionar cámara:</label>
-                                <select id="camera-select" class="form-input"></select>
-                            </div>
-
-                            <div id="scanner-container">
-                                <video id="scanner-video" style="width: 100%; height: auto;"></video>
-                            </div>
-                            <button id="close-scanner-btn" class="btn btn-cancel"
-                                style="margin-top: 1rem;">Cancelar</button>
-                        </div>
-                    </div>
                     <div id="menu-items" class="menu-items-grid" aria-label="Elementos del menú"></div>
                 </div>
                 <div class="pos-order-container">
@@ -487,6 +471,22 @@
             </div>
         </section>
     </main>
+    <div id="scanner-modal" class="modal hidden">
+        <div class="modal-content">
+            <h2 class="modal-title">Escaneando...</h2>
+
+            <div id="scanner-controls" class="form-group" style="display: none; margin-bottom: 1rem;">
+                <label for="camera-select" class="form-label">Seleccionar cámara:</label>
+                <select id="camera-select" class="form-input"></select>
+            </div>
+
+            <div id="scanner-container">
+                <video id="scanner-video" style="width: 100%; height: auto;"></video>
+            </div>
+            <button id="close-scanner-btn" class="btn btn-cancel"
+                style="margin-top: 1rem;">Cancelar</button>
+        </div>
+    </div>
     <div id="message-modal" class="modal hidden">
         <div class="modal-content">
             <h2 class="modal-title">Mensaje</h2>


### PR DESCRIPTION
The scanner modal was previously nested within the Point of Sale (POS) section's HTML. This caused a bug where triggering the scanner from the Products section would open the modal within the hidden POS section, making it invisible to the user.

This change moves the scanner modal's HTML from the `pos-section` to a global position in the `body`, alongside other modals. This makes it independent of any specific section's visibility and ensures it opens correctly regardless of where it is triggered from in the application.