### PR TITLE
Fix: Corrige el botón de Caja en el menú móvil

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
         <div id="backdrop" class="backdrop"></div>
         <div id="mobile-menu" class="mobile-menu">
             <button id="mobile-nav-pos" class="mobile-nav-btn">Punto de Venta</button>
-            <button id="nav-caja" class="nav-btn btn-caja">Caja</button>
+            <button id="mobile-nav-caja" class="mobile-nav-btn">Caja</button>
             <button id="mobile-nav-product-management" class="mobile-nav-btn">Productos</button>
             <button id="mobile-nav-customers" class="mobile-nav-btn">Clientes</button>
             <button id="mobile-nav-dashboard" class="mobile-nav-btn">Ventas</button>


### PR DESCRIPTION
El botón de la sección "Caja" en el menú de navegación móvil no funcionaba y tenía un estilo inconsistente.

Esto se debía a que el botón en `index.html` tenía un `id` duplicado ("nav-caja") y usaba clases de CSS de escritorio ("nav-btn btn-caja") en lugar de las móviles.

Esta corrección actualiza el `id` a "mobile-nav-caja" para que coincida con el selector de eventos en `app.js` y cambia la clase a "mobile-nav-btn" para unificar el estilo con los demás botones del menú móvil.