### PR TITLE
FASE 5 — Reportes cloud PRO hibridos

### DIFF
--- a/informe_supabase_fase5_reportes_cloud.txt
+++ b/informe_supabase_fase5_reportes_cloud.txt
@@ -1,0 +1,80 @@
+INFORME SUPABASE - FASE 5 REPORTES CLOUD PRO
+Fecha: 2026-06-24
+Proyecto: odlrhijtfyavryeqivaa
+
+Objetivo
+Se implemento la base de reportes cloud PRO para clientes, productos/catalogo, caja, movimientos de caja, credito/abonos y customer ledger.
+
+Regla critica
+No se creo pos_sales. No se implementaron ventas cloud. Ventas, historial, utilidad real y mermas siguen siendo locales/cache del dispositivo hasta una fase futura.
+
+Feature flags
+public.plans.features:
+- pro_monthly: cloud_reports_sync = true
+- free_trial: cloud_reports_sync = false
+- basic_monthly: cloud_reports_sync = false
+
+RPCs creadas
+- public.pos_get_reports_overview
+- public.pos_get_cash_report
+- public.pos_get_customer_credit_report
+- public.pos_get_product_catalog_report
+- public.pos_get_report_timeseries
+- public.pos_export_report_data
+
+Helpers privados creados
+- private.assert_cloud_reports_sync_enabled
+- private.reports_date_range
+- private.reports_scope_allowed
+- private.reports_staff_filter
+- private.safe_numeric
+- private.reports_is_admin
+- private.reports_has_permission
+- private.reports_allowed
+- private.reports_audit_allowed
+- private.reports_source_metadata
+
+Fuentes oficiales cloud
+- cash
+- customer_credit
+- customers
+- products
+
+Fuentes locales/cache
+- sales
+- waste
+
+Permisos
+- Admin ve reportes globales.
+- Staff requiere permiso reportes o reports.
+- Staff normal queda limitado a sus propios datos.
+- Auditor global requiere caja_auditoria, cash_audit, reportes_globales o reports_global.
+
+RLS
+Se valido RLS activo en:
+- pos_customers
+- pos_categories
+- pos_products
+- pos_product_batches
+- pos_cash_sessions
+- pos_cash_movements
+- pos_customer_ledger
+- pos_sync_events
+
+Pruebas realizadas
+- La migracion aplico correctamente.
+- cloud_reports_sync quedo true solo en pro_monthly.
+- Las RPCs existen.
+- Las RPCs publicas nuevas son SECURITY DEFINER.
+- public.pos_sales no existe.
+- RLS activo en tablas principales.
+
+Frontend
+Se agrego src/services/reports y DashboardPage usa reportsRepository. El dashboard muestra modo mixto/cache/local y mantiene ventas locales etiquetadas.
+
+Pendientes
+- Ejecutar npm run build en desarrollo o CI.
+- Probar admin PRO online.
+- Probar staff con/sin permiso reportes.
+- Probar PRO offline con snapshot cacheado.
+- Implementar una fase futura de ventas cloud antes de utilidad real cloud.

--- a/src/pages/DashboardPage.jsx
+++ b/src/pages/DashboardPage.jsx
@@ -23,6 +23,8 @@ import SaleCancellationModal from '../components/dashboard/SaleCancellationModal
 
 import { loadData, STORES } from '../services/database';
 import { reportingService } from '../services/db/reporting';
+import { reportsRepository, REPORT_SYNC_UPDATED_EVENT } from '../services/reports/reportsRepository';
+import { getReportSourceLabel, REPORT_SOURCE_MODES } from '../services/reports/reportSourceBadges';
 import { showMessageModal } from '../services/utils';
 import { useFeatureConfig } from '../hooks/useFeatureConfig';
 import './DashboardPage.css';
@@ -62,12 +64,43 @@ const buildWarningsMessage = (warnings = []) => {
   return `\n\nAdvertencias:\n${preview}${tail}`;
 };
 
+const ReportSourceBanner = ({ source }) => {
+  if (!source) return null;
+
+  const isMixed = source.mode === REPORT_SOURCE_MODES.MIXED;
+  const isCache = source.mode === REPORT_SOURCE_MODES.CACHE || source.stale;
+  const warnings = Array.isArray(source.warnings) ? source.warnings : [];
+
+  return (
+    <div className={`data-warning-banner report-source-banner report-source-banner--${source.mode || 'local'}`}>
+      <span className="data-warning-icon">
+        <Save size={22} strokeWidth={1.5} />
+      </span>
+      <div>
+        <strong>{getReportSourceLabel(source)}</strong>
+        <p>
+          {isMixed
+            ? 'Modo PRO cloud: caja, abonos, clientes y productos usan datos cloud oficiales. Ventas, utilidad real, historial y mermas siguen usando datos locales de este dispositivo hasta activar ventas cloud.'
+            : isCache
+              ? 'Sin conexion o servicio no disponible: se muestra el ultimo snapshot cloud guardado. Puede estar desactualizado.'
+              : 'Reporte local de este dispositivo.'}
+        </p>
+        {warnings.length > 0 && (
+          <small>{warnings.slice(0, 2).join(' ')}</small>
+        )}
+      </div>
+    </div>
+  );
+};
+
 export default function DashboardPage() {
   const [customers, setCustomers] = useState([]);
   const [reportingData, setReportingData] = useState({
     sales: [],
     wasteLogs: [],
     menu: [],
+    overviewReport: null,
+    reportSource: null,
     isLoading: true,
     refreshKey: 0
   });
@@ -79,7 +112,7 @@ export default function DashboardPage() {
   const licenseDetails = useAppStore((state) => state.licenseDetails);
   const canUseAIAgents = useMemo(() => hasAIAgentsEntitlement(licenseDetails), [licenseDetails]);
 
-  // 1. ESTADÍSTICAS
+  // 1. ESTADISTICAS
   const stats = useStatsStore((state) => state.stats);
   const loadStats = useStatsStore((state) => state.loadStats);
   const isStatsLoading = useStatsStore((state) => state.isLoading);
@@ -113,32 +146,54 @@ export default function DashboardPage() {
   // 4. PAPELERA
   const loadRecycleBin = useRecycleBinStore(state => state.loadRecycleBin);
 
-  const loadCustomers = async () => {
+  const loadCustomers = useCallback(async () => {
     try {
       const customersData = await loadData(STORES.CUSTOMERS);
       setCustomers(customersData || []);
     } catch (error) {
-      Logger.error("Error cargando clientes:", error);
+      Logger.error('Error cargando clientes:', error);
       setCustomers([]);
     }
-  };
+  }, []);
 
   const loadDashboardReporting = useCallback(async () => {
     setReportingData((current) => ({ ...current, isLoading: true }));
 
     try {
-      const report = await reportingService.getDashboardReport({
-        rangoFechas: null,
-        rubros: features.activeRubros,
-        incluirCanceladas: false,
-        incluirMermas: true,
-        incluirProductos: true
-      });
+      const [localReportResult, cloudOverviewResult] = await Promise.allSettled([
+        reportingService.getDashboardReport({
+          rangoFechas: null,
+          rubros: features.activeRubros,
+          incluirCanceladas: false,
+          incluirMermas: true,
+          incluirProductos: true
+        }),
+        reportsRepository.getOverviewReport({
+          rubros: features.activeRubros,
+          scope: 'mine'
+        })
+      ]);
+
+      const localReport = localReportResult.status === 'fulfilled'
+        ? localReportResult.value
+        : { sales: [], wasteLogs: [], menu: [] };
+      const overviewReport = cloudOverviewResult.status === 'fulfilled'
+        ? cloudOverviewResult.value
+        : null;
+
+      if (localReportResult.status === 'rejected') {
+        Logger.error('Error cargando datos locales del dashboard:', localReportResult.reason);
+      }
+      if (cloudOverviewResult.status === 'rejected') {
+        Logger.warn('No se pudo cargar reporte cloud/hibrido:', cloudOverviewResult.reason);
+      }
 
       setReportingData({
-        sales: report.sales || [],
-        wasteLogs: report.wasteLogs || [],
-        menu: report.menu || [],
+        sales: localReport.sales || [],
+        wasteLogs: localReport.wasteLogs || [],
+        menu: localReport.menu || [],
+        overviewReport,
+        reportSource: overviewReport?.source || null,
         isLoading: false,
         refreshKey: Date.now()
       });
@@ -153,22 +208,41 @@ export default function DashboardPage() {
   }, [features.activeRubros]);
 
   useEffect(() => {
-    Logger.log("🔄 Actualizando Dashboard...");
+    Logger.log('Actualizando Dashboard...');
     loadStats();
     loadRecentSales();
     loadDashboardReporting();
     loadCustomers();
-  }, [loadDashboardReporting, loadRecentSales, loadStats]);
+  }, [loadDashboardReporting, loadRecentSales, loadStats, loadCustomers]);
+
+  useEffect(() => {
+    const refreshReportSources = () => {
+      loadDashboardReporting();
+      loadCustomers();
+      loadStats();
+    };
+
+    const events = [
+      REPORT_SYNC_UPDATED_EVENT,
+      'lanzo:customers-sync-updated',
+      'lanzo:customer-credit-sync-updated',
+      'lanzo:cash-sync-updated',
+      'lanzo:products-sync-updated'
+    ];
+
+    events.forEach((eventName) => window.addEventListener(eventName, refreshReportSources));
+    return () => events.forEach((eventName) => window.removeEventListener(eventName, refreshReportSources));
+  }, [loadDashboardReporting, loadCustomers, loadStats]);
 
   useEffect(() => {
     const tabParam = searchParams.get('tab');
     const tabMap = {
-      'stats': 'stats',
-      'tips': 'tips',
-      'restock': 'restock',
-      'history': 'history',
-      'expiration': 'expiration',
-      'waste': 'waste'
+      stats: 'stats',
+      tips: 'tips',
+      restock: 'restock',
+      history: 'history',
+      expiration: 'expiration',
+      waste: 'waste'
     };
 
     if (tabParam && tabMap[tabParam]) {
@@ -191,7 +265,7 @@ export default function DashboardPage() {
   };
 
   const handleArchiveCancelledSale = async (sale) => {
-    if (!window.confirm('¿Mover esta venta cancelada a la papelera?')) return;
+    if (!window.confirm('Mover esta venta cancelada a la papelera?')) return;
     const result = await archiveCancelledSale(sale.id);
     if (!result.success) {
       showMessageModal(result.message || 'No se pudo mover la venta a papelera.', null, { type: 'error' });
@@ -270,98 +344,53 @@ export default function DashboardPage() {
 
   return (
     <>
-      {/* --- PESTAÑAS DE NAVEGACIÓN --- */}
       <div className="tabs-container" id="sales-tabs">
-        <button
-          className={`tab-btn ${activeTab === 'stats' ? 'active' : ''}`}
-          onClick={() => handleTabChange('stats')}
-        >
-          Estadísticas Clave
-        </button>
-
-        <button
-          className={`tab-btn ${activeTab === 'tips' ? 'active' : ''}`}
-          onClick={() => handleTabChange('tips')}
-        >
-          Consejos Lan
-        </button>
-
-        <button
-          className={`tab-btn ${activeTab === 'restock' ? 'active' : ''}`}
-          onClick={() => handleTabChange('restock')}
-        >
-          Reabastecimiento
-        </button>
-
-        <button
-          className={`tab-btn ${activeTab === 'history' ? 'active' : ''}`}
-          onClick={() => handleTabChange('history')}
-        >
-          Historial y Papelera
-        </button>
-
-        <button
-          className={`tab-btn ${activeTab === 'expiration' ? 'active' : ''}`}
-          onClick={() => handleTabChange('expiration')}
-        >
-          Caducidad
-        </button>
-
+        <button className={`tab-btn ${activeTab === 'stats' ? 'active' : ''}`} onClick={() => handleTabChange('stats')}>Estadisticas Clave</button>
+        <button className={`tab-btn ${activeTab === 'tips' ? 'active' : ''}`} onClick={() => handleTabChange('tips')}>Consejos Lan</button>
+        <button className={`tab-btn ${activeTab === 'restock' ? 'active' : ''}`} onClick={() => handleTabChange('restock')}>Reabastecimiento</button>
+        <button className={`tab-btn ${activeTab === 'history' ? 'active' : ''}`} onClick={() => handleTabChange('history')}>Historial y Papelera</button>
+        <button className={`tab-btn ${activeTab === 'expiration' ? 'active' : ''}`} onClick={() => handleTabChange('expiration')}>Caducidad</button>
         {features.hasWaste && (
-          <button
-            className={`tab-btn ${activeTab === 'waste' ? 'active' : ''}`}
-            onClick={() => handleTabChange('waste')}
-            style={{ color: activeTab === 'waste' ? 'var(--error-color)' : '' }}
-          >
-            Mermas
-          </button>
+          <button className={`tab-btn ${activeTab === 'waste' ? 'active' : ''}`} onClick={() => handleTabChange('waste')} style={{ color: activeTab === 'waste' ? 'var(--error-color)' : '' }}>Mermas</button>
         )}
       </div>
 
-      {/* --- CONTENIDO DE LAS PESTAÑAS --- */}
+      <ReportSourceBanner source={reportingData.reportSource} />
 
-      {/* 1. ESTADÍSTICAS */}
       {activeTab === 'stats' && (
         <StatsGrid
           stats={stats}
           customers={customers}
           reportRefreshKey={reportingData.refreshKey}
           activeRubros={features.activeRubros}
+          reportData={reportingData.overviewReport}
+          reportSource={reportingData.reportSource}
+          isCloudReport={reportingData.reportSource?.mode === REPORT_SOURCE_MODES.CLOUD}
+          isMixedReport={reportingData.reportSource?.mode === REPORT_SOURCE_MODES.MIXED}
+          isStale={Boolean(reportingData.reportSource?.stale)}
         />
       )}
 
-      {/* 2. REABASTECIMIENTO */}
       {activeTab === 'restock' && (
-        <RestockSuggestions />
+        <RestockSuggestions reportData={reportingData.overviewReport} reportSource={reportingData.reportSource} />
       )}
 
-      {/* 3. HISTORIAL Y PAPELERA (MEJORADO) */}
       {activeTab === 'history' && (
         <div className="tab-content fade-in">
-          {/* Banner de Advertencia */}
           <div className="data-warning-banner">
-            <span className="data-warning-icon">
-              <Save size={24} strokeWidth={1.5} />
-            </span>
+            <span className="data-warning-icon"><Save size={24} strokeWidth={1.5} /></span>
             <div>
-              <strong>Importante: Tus datos viven en este dispositivo.</strong>
+              <strong>Importante: historial de ventas local.</strong>
               <p>
-                Te recomendamos hacer una <strong>Copia de Seguridad</strong> semanalmente.
-                <button
-                  onClick={() => navigate('/settings')}
-                  className="link-button"
-                  style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}
-                >
+                Las ventas e historial se leen desde este dispositivo. Caja, abonos y credito pueden venir de cloud en PRO.
+                <button onClick={() => navigate('/settings')} className="link-button" style={{ display: 'inline-flex', alignItems: 'center', gap: '4px' }}>
                   Ir a Respaldar ahora <ArrowRight size={16} />
                 </button>
               </p>
             </div>
           </div>
 
-          {/* Grid Principal: Historial (Izquierda) + Papelera (Derecha) */}
           <div className="history-layout-grid">
-
-            {/* Sección Principal: Historial */}
             <section className="dashboard-panel history-panel">
               <div className="panel-header">
                 <h3><BarChart3 size={20} /> Historial de Movimientos</h3>
@@ -377,52 +406,32 @@ export default function DashboardPage() {
                   hasMore={hasMoreSales}
                   currentPageIndex={currentSalesPageIndex}
                   isLoading={isSalesLoading}
+                  reportSource={reportingData.reportSource}
                 />
               </div>
             </section>
 
-            {/* Sección Lateral: Papelera */}
             <section className="dashboard-panel recycle-panel">
               <div className="panel-header danger-theme">
                 <h3><Trash2 size={20} /> Papelera</h3>
                 <span className="panel-subtitle">Elementos eliminados</span>
               </div>
-              <div className="panel-body">
-                <RecycleBin />
-              </div>
+              <div className="panel-body"><RecycleBin /></div>
             </section>
-
           </div>
         </div>
       )}
 
-      {/* 4. CONSEJOS */}
       {activeTab === 'tips' && (
         canUseAIAgents ? (
-          <OperationalDiagnostics
-            sales={analyticsSales}
-            menu={analyticsMenu}
-            customers={customers}
-            wasteLogs={analyticsWasteLogs}
-          />
+          <OperationalDiagnostics sales={analyticsSales} menu={analyticsMenu} customers={customers} wasteLogs={analyticsWasteLogs} reportData={reportingData.overviewReport} reportSource={reportingData.reportSource} />
         ) : (
-          <BusinessTips
-            sales={analyticsSales}
-            menu={analyticsMenu}
-            customers={customers}
-            wasteLogs={analyticsWasteLogs}
-            activeRubros={features.activeRubros}
-            onNavigate={(route) => navigate(route)}
-          />
+          <BusinessTips sales={analyticsSales} menu={analyticsMenu} customers={customers} wasteLogs={analyticsWasteLogs} activeRubros={features.activeRubros} reportData={reportingData.overviewReport} reportSource={reportingData.reportSource} onNavigate={(route) => navigate(route)} />
         )
       )}
 
-      {/* 5. CADUCIDAD */}
-      {activeTab === 'expiration' && (
-        <ExpirationAlert />
-      )}
+      {activeTab === 'expiration' && <ExpirationAlert reportData={reportingData.overviewReport} reportSource={reportingData.reportSource} />}
 
-      {/* 6. MERMAS */}
       {activeTab === 'waste' && features.hasWaste && (
         <WasteHistory
           logs={wasteLogs}
@@ -434,6 +443,7 @@ export default function DashboardPage() {
           currentWastePageIndex={currentWastePageIndex}
           isWasteLoading={isWasteLoading}
           activeRubros={features.activeRubros}
+          reportSource={reportingData.reportSource}
         />
       )}
 

--- a/src/services/reports/reportSourceBadges.js
+++ b/src/services/reports/reportSourceBadges.js
@@ -1,0 +1,37 @@
+export const REPORT_SOURCE_MODES = Object.freeze({
+  CLOUD: 'cloud',
+  LOCAL: 'local',
+  MIXED: 'mixed',
+  CACHE: 'cache'
+});
+
+export const REPORT_SOURCE_LABELS = Object.freeze({
+  cloud: 'Cloud oficial',
+  local: 'Local',
+  mixed: 'Mixto',
+  cache: 'Ultimo snapshot'
+});
+
+export const CLOUD_OFFICIAL_MODULES = Object.freeze(['cash', 'customer_credit', 'customers', 'products']);
+export const LOCAL_ONLY_MODULES = Object.freeze(['sales', 'waste']);
+
+export const DEFAULT_MIXED_WARNINGS = Object.freeze([
+  'Ventas cloud completas todavia no estan implementadas.',
+  'Ventas, utilidad real, historial y mermas siguen usando datos locales de este dispositivo.',
+  'Caja, abonos, clientes y catalogo usan datos cloud oficiales cuando el dispositivo esta en linea.'
+]);
+
+export const buildReportSource = ({ mode = 'local', official = [], local = [], warnings = [], stale = false, generatedAt = null } = {}) => ({
+  mode,
+  official: Array.isArray(official) ? official : [],
+  local: Array.isArray(local) ? local : [],
+  warnings: Array.isArray(warnings) ? warnings : [],
+  stale: Boolean(stale),
+  generatedAt
+});
+
+export const getReportSourceLabel = (source = {}) => REPORT_SOURCE_LABELS[source.mode] || REPORT_SOURCE_LABELS.local;
+export const isCloudReportSource = (source = {}) => source.mode === REPORT_SOURCE_MODES.CLOUD;
+export const isMixedReportSource = (source = {}) => source.mode === REPORT_SOURCE_MODES.MIXED;
+export const isCacheReportSource = (source = {}) => source.mode === REPORT_SOURCE_MODES.CACHE;
+export const isLocalReportSource = (source = {}) => source.mode === REPORT_SOURCE_MODES.LOCAL;

--- a/src/services/reports/reportsCacheService.js
+++ b/src/services/reports/reportsCacheService.js
@@ -1,0 +1,80 @@
+import { db, STORES } from '../db/dexie';
+
+const REPORT_CACHE_PREFIX = 'reports_cache:';
+
+const stableStringify = (value) => {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(',')}]`;
+
+  return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+};
+
+const hashString = (input = '') => {
+  let hash = 0;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = ((hash << 5) - hash) + input.charCodeAt(i);
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(36);
+};
+
+const buildCacheKey = (reportType, filters = {}) => `${REPORT_CACHE_PREFIX}${reportType}:${hashString(stableStringify(filters || {}))}`;
+
+export const reportsCacheService = {
+  buildCacheKey,
+
+  async saveSnapshot(reportType, filters, payload, source = {}) {
+    if (!reportType || !payload) return null;
+    if (!db.isOpen()) await db.open();
+
+    const record = {
+      key: buildCacheKey(reportType, filters),
+      value: {
+        reportType,
+        filtersHash: hashString(stableStringify(filters || {})),
+        filters: filters || {},
+        payload,
+        source,
+        generatedAt: new Date().toISOString(),
+        stale: false
+      }
+    };
+
+    await db.table(STORES.SYNC_CACHE).put(record);
+    return record.value;
+  },
+
+  async getSnapshot(reportType, filters = {}) {
+    if (!reportType) return null;
+    if (!db.isOpen()) await db.open();
+
+    const record = await db.table(STORES.SYNC_CACHE).get(buildCacheKey(reportType, filters));
+    if (!record?.value?.payload) return null;
+
+    return {
+      ...record.value,
+      stale: true,
+      payload: {
+        ...record.value.payload,
+        source: {
+          ...(record.value.payload.source || record.value.source || {}),
+          mode: 'cache',
+          stale: true
+        }
+      }
+    };
+  },
+
+  async invalidateReports() {
+    if (!db.isOpen()) await db.open();
+    const rows = await db.table(STORES.SYNC_CACHE)
+      .filter((row) => String(row?.key || '').startsWith(REPORT_CACHE_PREFIX))
+      .toArray();
+
+    if (!rows.length) return 0;
+    await db.table(STORES.SYNC_CACHE).bulkDelete(rows.map((row) => row.key));
+    return rows.length;
+  }
+};
+
+export default reportsCacheService;

--- a/src/services/reports/reportsCloudRepository.js
+++ b/src/services/reports/reportsCloudRepository.js
@@ -1,0 +1,123 @@
+import { supabaseClient } from '../supabase';
+import { buildPosSyncAuthContext } from '../sync/posSyncClient';
+import { SYNC_LIMITS } from '../sync/syncConstants';
+
+const parseRpcPayload = (data) => {
+  if (typeof data === 'string') return JSON.parse(data);
+  return data || {};
+};
+
+const assertSupabase = () => {
+  if (!supabaseClient) throw new Error('SUPABASE_NOT_CONFIGURED');
+};
+
+const normalizeLimit = (limit = 100) => Math.min(
+  Math.max(Number(limit) || 100, 1),
+  SYNC_LIMITS.MAX_PULL_LIMIT
+);
+
+const buildBaseRpcArgs = async (licenseKey) => {
+  const context = await buildPosSyncAuthContext({ licenseKey });
+
+  if (!context.licenseKey || !context.deviceFingerprint || !context.securityToken) {
+    throw new Error('POS_SYNC_AUTH_CONTEXT_INCOMPLETE');
+  }
+
+  return {
+    p_license_key: context.licenseKey,
+    p_device_fingerprint: context.deviceFingerprint,
+    p_security_token: context.securityToken,
+    p_staff_session_token: context.staffSessionToken || null
+  };
+};
+
+export const reportsCloudRepository = {
+  async getOverviewReport({ licenseKey, dateFrom = null, dateTo = null, scope = 'mine' } = {}) {
+    assertSupabase();
+    const baseArgs = await buildBaseRpcArgs(licenseKey);
+    const { data, error } = await supabaseClient.rpc('pos_get_reports_overview', {
+      ...baseArgs,
+      p_date_from: dateFrom,
+      p_date_to: dateTo,
+      p_scope: scope || 'mine'
+    });
+    if (error) throw error;
+    return parseRpcPayload(data);
+  },
+
+  async getCashReport({ licenseKey, dateFrom = null, dateTo = null, staffUserId = null, status = null, limit = 100, offset = 0 } = {}) {
+    assertSupabase();
+    const baseArgs = await buildBaseRpcArgs(licenseKey);
+    const { data, error } = await supabaseClient.rpc('pos_get_cash_report', {
+      ...baseArgs,
+      p_date_from: dateFrom,
+      p_date_to: dateTo,
+      p_staff_user_id: staffUserId,
+      p_status: status,
+      p_limit: normalizeLimit(limit),
+      p_offset: Math.max(Number(offset) || 0, 0)
+    });
+    if (error) throw error;
+    return parseRpcPayload(data);
+  },
+
+  async getCustomerCreditReport({ licenseKey, dateFrom = null, dateTo = null, customerId = null, limit = 100, offset = 0 } = {}) {
+    assertSupabase();
+    const baseArgs = await buildBaseRpcArgs(licenseKey);
+    const { data, error } = await supabaseClient.rpc('pos_get_customer_credit_report', {
+      ...baseArgs,
+      p_date_from: dateFrom,
+      p_date_to: dateTo,
+      p_customer_id: customerId,
+      p_limit: normalizeLimit(limit),
+      p_offset: Math.max(Number(offset) || 0, 0)
+    });
+    if (error) throw error;
+    return parseRpcPayload(data);
+  },
+
+  async getProductCatalogReport({ licenseKey, dateFrom = null, dateTo = null, limit = 100, offset = 0 } = {}) {
+    assertSupabase();
+    const baseArgs = await buildBaseRpcArgs(licenseKey);
+    const { data, error } = await supabaseClient.rpc('pos_get_product_catalog_report', {
+      ...baseArgs,
+      p_date_from: dateFrom,
+      p_date_to: dateTo,
+      p_limit: normalizeLimit(limit),
+      p_offset: Math.max(Number(offset) || 0, 0)
+    });
+    if (error) throw error;
+    return parseRpcPayload(data);
+  },
+
+  async getTimeseriesReport({ licenseKey, metric = 'cash_entries', granularity = 'day', dateFrom = null, dateTo = null } = {}) {
+    assertSupabase();
+    const baseArgs = await buildBaseRpcArgs(licenseKey);
+    const { data, error } = await supabaseClient.rpc('pos_get_report_timeseries', {
+      ...baseArgs,
+      p_metric: metric,
+      p_granularity: granularity,
+      p_date_from: dateFrom,
+      p_date_to: dateTo
+    });
+    if (error) throw error;
+    return parseRpcPayload(data);
+  },
+
+  async exportReportData({ licenseKey, reportType = 'cash_movements', dateFrom = null, dateTo = null, limit = 1000, offset = 0 } = {}) {
+    assertSupabase();
+    const baseArgs = await buildBaseRpcArgs(licenseKey);
+    const { data, error } = await supabaseClient.rpc('pos_export_report_data', {
+      ...baseArgs,
+      p_report_type: reportType,
+      p_date_from: dateFrom,
+      p_date_to: dateTo,
+      p_limit: Math.min(Math.max(Number(limit) || 1000, 1), 5000),
+      p_offset: Math.max(Number(offset) || 0, 0)
+    });
+    if (error) throw error;
+    return parseRpcPayload(data);
+  }
+};
+
+export default reportsCloudRepository;

--- a/src/services/reports/reportsLocalRepository.js
+++ b/src/services/reports/reportsLocalRepository.js
@@ -1,0 +1,101 @@
+import { db, STORES } from '../db/dexie';
+import { reportingService } from '../db/reporting';
+import { reportsMapper } from './reportsMapper';
+
+const sum = (rows = [], selector = (row) => row) => rows.reduce((total, row) => total + (Number(selector(row)) || 0), 0);
+
+const inventoryValue = (menu = []) => sum(menu, (product) => Math.max(Number(product.stock || 0) - Number(product.committedStock || 0), 0) * Number(product.cost || 0));
+
+const buildLocalOverview = ({ sales = [], wasteLogs = [], menu = [], customers = [] } = {}) => ({
+  sales_total: sum(sales, (sale) => sale.total),
+  sales_count: sales.length,
+  waste_total: sum(wasteLogs, (log) => log.lossAmount || log.amount || log.cost),
+  waste_count: wasteLogs.length,
+  customers_total: customers.length,
+  customers_with_debt: customers.filter((customer) => Number(customer.debt || 0) > 0).length,
+  debt_total: sum(customers, (customer) => customer.debt),
+  products_active: menu.filter((product) => product.isActive !== false).length,
+  products_without_stock: menu.filter((product) => product.isActive !== false && product.trackStock !== false && Number(product.stock || 0) <= 0).length,
+  inventory_value_approx: inventoryValue(menu)
+});
+
+export const reportsLocalRepository = {
+  async getOverviewReport(filters = {}) {
+    const report = await reportingService.getDashboardReport({
+      rangoFechas: filters.rangoFechas || filters.dateRange || null,
+      rubros: filters.rubros || [],
+      incluirCanceladas: false,
+      incluirMermas: true,
+      incluirProductos: true,
+      incluirClientes: true
+    });
+
+    return reportsMapper.normalizeLocalOverview({
+      ...report,
+      overview: buildLocalOverview(report)
+    });
+  },
+
+  async getCashReport() {
+    if (!db.isOpen()) await db.open();
+    const [sessions, movements] = await Promise.all([
+      db.table(STORES.CAJAS).toArray(),
+      db.table(STORES.MOVIMIENTOS_CAJA).toArray()
+    ]);
+
+    return reportsMapper.normalizeReportPayload({
+      success: true,
+      generated_at: new Date().toISOString(),
+      summary: {
+        open_sessions: sessions.filter((session) => session.estado === 'abierta' || session.status === 'open').length,
+        closed_sessions: sessions.filter((session) => session.estado === 'cerrada' || session.status === 'closed').length,
+        movement_count: movements.length
+      },
+      sessions,
+      movements,
+      source: { mode: 'local', official: [], local: ['cash'], warnings: ['Caja local de este dispositivo.'] }
+    }, { mode: 'local' });
+  },
+
+  async getCustomerCreditReport() {
+    if (!db.isOpen()) await db.open();
+    const customers = await db.table(STORES.CUSTOMERS).toArray();
+    const ledger = await db.table(STORES.CUSTOMER_LEDGER).toArray().catch(() => []);
+
+    return reportsMapper.normalizeReportPayload({
+      success: true,
+      generated_at: new Date().toISOString(),
+      summary: {
+        debt_total: sum(customers, (customer) => customer.debt),
+        customers_total: customers.length,
+        customers_with_debt: customers.filter((customer) => Number(customer.debt || 0) > 0).length
+      },
+      top_debtors: customers.filter((customer) => Number(customer.debt || 0) > 0).sort((a, b) => Number(b.debt || 0) - Number(a.debt || 0)).slice(0, 25),
+      ledger,
+      source: { mode: 'local', official: [], local: ['customer_credit'], warnings: ['Credito local de este dispositivo.'] }
+    }, { mode: 'local' });
+  },
+
+  async getProductCatalogReport() {
+    if (!db.isOpen()) await db.open();
+    const menu = await db.table(STORES.MENU).toArray();
+    return reportsMapper.normalizeReportPayload({
+      success: true,
+      generated_at: new Date().toISOString(),
+      summary: {
+        products_active: menu.filter((product) => product.isActive !== false).length,
+        products_inactive: menu.filter((product) => product.isActive === false).length,
+        products_without_stock: menu.filter((product) => product.isActive !== false && product.trackStock !== false && Number(product.stock || 0) <= 0).length,
+        inventory_value_approx: inventoryValue(menu)
+      },
+      inventory: menu,
+      source: { mode: 'local', official: [], local: ['products'], warnings: ['Catalogo local de este dispositivo.'] }
+    }, { mode: 'local' });
+  },
+
+  async getTimeseriesReport() {
+    return reportsMapper.normalizeReportPayload({ success: true, generated_at: new Date().toISOString(), rows: [], source: { mode: 'local', official: [], local: ['sales', 'waste'], warnings: ['Series locales limitadas al dispositivo.'] } }, { mode: 'local' });
+  }
+};
+
+export default reportsLocalRepository;

--- a/src/services/reports/reportsMapper.js
+++ b/src/services/reports/reportsMapper.js
@@ -1,0 +1,99 @@
+import {
+  CLOUD_OFFICIAL_MODULES,
+  DEFAULT_MIXED_WARNINGS,
+  LOCAL_ONLY_MODULES,
+  REPORT_SOURCE_MODES,
+  buildReportSource
+} from './reportSourceBadges';
+
+const parsePayload = (payload) => {
+  if (typeof payload === 'string') {
+    try {
+      return JSON.parse(payload);
+    } catch {
+      return {};
+    }
+  }
+  return payload || {};
+};
+
+const normalizeWarnings = (warnings = []) => (
+  Array.isArray(warnings) ? warnings.filter(Boolean) : [warnings].filter(Boolean)
+);
+
+const normalizeSource = (payload = {}, modeOverride = null, { stale = false } = {}) => {
+  const rawSource = payload.source || payload.data_sources || {};
+  const mode = modeOverride || rawSource.mode || REPORT_SOURCE_MODES.LOCAL;
+
+  return buildReportSource({
+    mode,
+    official: rawSource.official || (mode === REPORT_SOURCE_MODES.LOCAL ? [] : CLOUD_OFFICIAL_MODULES),
+    local: rawSource.local || (mode === REPORT_SOURCE_MODES.LOCAL ? ['all'] : LOCAL_ONLY_MODULES),
+    warnings: normalizeWarnings(rawSource.warnings || payload.warnings || []),
+    stale,
+    generatedAt: payload.generated_at || payload.generatedAt || null
+  });
+};
+
+export const reportsMapper = {
+  normalizeOverview(payload, { mode = null, stale = false } = {}) {
+    const data = parsePayload(payload);
+    const sourceMode = mode || data.source?.mode || REPORT_SOURCE_MODES.LOCAL;
+    return {
+      success: data.success !== false,
+      generatedAt: data.generated_at || data.generatedAt || null,
+      dateRange: data.date_range || data.dateRange || null,
+      overview: data.overview || {},
+      cash: data.cash || null,
+      customerCredit: data.customer_credit || data.customerCredit || null,
+      products: data.products || null,
+      warnings: normalizeWarnings(data.warnings || data.source?.warnings || []),
+      source: normalizeSource(data, sourceMode, { stale }),
+      raw: data
+    };
+  },
+
+  normalizeCloudOverviewAsMixed(payload, { stale = false } = {}) {
+    const mapped = this.normalizeOverview(payload, { mode: stale ? REPORT_SOURCE_MODES.CACHE : REPORT_SOURCE_MODES.MIXED, stale });
+    mapped.source.official = CLOUD_OFFICIAL_MODULES;
+    mapped.source.local = LOCAL_ONLY_MODULES;
+    mapped.source.warnings = Array.from(new Set([
+      ...DEFAULT_MIXED_WARNINGS,
+      ...mapped.source.warnings
+    ]));
+    return mapped;
+  },
+
+  normalizeReportPayload(payload, { mode = REPORT_SOURCE_MODES.CLOUD, stale = false } = {}) {
+    const data = parsePayload(payload);
+    return {
+      ...data,
+      success: data.success !== false,
+      generatedAt: data.generated_at || data.generatedAt || null,
+      source: normalizeSource(data, mode, { stale })
+    };
+  },
+
+  normalizeLocalOverview(payload = {}) {
+    return {
+      success: true,
+      generatedAt: new Date().toISOString(),
+      overview: payload.overview || {},
+      sales: payload.sales || [],
+      wasteLogs: payload.wasteLogs || [],
+      menu: payload.menu || [],
+      customers: payload.customers || [],
+      warnings: [],
+      source: buildReportSource({
+        mode: REPORT_SOURCE_MODES.LOCAL,
+        official: [],
+        local: ['all'],
+        warnings: ['Reporte local de este dispositivo.'],
+        generatedAt: new Date().toISOString()
+      }),
+      raw: payload
+    };
+  }
+};
+
+export default reportsMapper;

--- a/src/services/reports/reportsRepository.js
+++ b/src/services/reports/reportsRepository.js
@@ -1,10 +1,11 @@
 import { useAppStore } from '../../store/useAppStore';
 import {
   getLicenseKeyFromDetails,
+  getPlanFeaturesFromLicenseDetails,
   isCloudCashSyncEnabled,
   isCloudCustomerCreditSyncEnabled,
   isCloudProductsSyncEnabled,
-  isCloudReportsSyncEnabled
+  isFeatureEnabled
 } from '../sync/syncConstants';
 import { reportsCloudRepository } from './reportsCloudRepository';
 import { reportsLocalRepository } from './reportsLocalRepository';
@@ -15,6 +16,11 @@ import { REPORT_SOURCE_MODES } from './reportSourceBadges';
 export const REPORT_SYNC_UPDATED_EVENT = 'lanzo:reports-sync-updated';
 
 const isOnline = () => typeof navigator === 'undefined' || navigator.onLine !== false;
+
+const isCloudReportsSyncEnabled = (licenseDetails = {}) => {
+  const features = getPlanFeaturesFromLicenseDetails(licenseDetails);
+  return isFeatureEnabled(features, 'cloud_pos_sync') && isFeatureEnabled(features, 'cloud_reports_sync');
+};
 
 const getMode = () => {
   const state = useAppStore.getState();

--- a/src/services/reports/reportsRepository.js
+++ b/src/services/reports/reportsRepository.js
@@ -1,0 +1,168 @@
+import { useAppStore } from '../../store/useAppStore';
+import {
+  getLicenseKeyFromDetails,
+  isCloudCashSyncEnabled,
+  isCloudCustomerCreditSyncEnabled,
+  isCloudProductsSyncEnabled,
+  isCloudReportsSyncEnabled
+} from '../sync/syncConstants';
+import { reportsCloudRepository } from './reportsCloudRepository';
+import { reportsLocalRepository } from './reportsLocalRepository';
+import { reportsMapper } from './reportsMapper';
+import { reportsCacheService } from './reportsCacheService';
+import { REPORT_SOURCE_MODES } from './reportSourceBadges';
+
+export const REPORT_SYNC_UPDATED_EVENT = 'lanzo:reports-sync-updated';
+
+const isOnline = () => typeof navigator === 'undefined' || navigator.onLine !== false;
+
+const getMode = () => {
+  const state = useAppStore.getState();
+  const licenseDetails = state?.licenseDetails || null;
+  const licenseKey = getLicenseKeyFromDetails(licenseDetails);
+
+  return {
+    licenseDetails,
+    licenseKey,
+    cloudReports: Boolean(licenseKey && isCloudReportsSyncEnabled(licenseDetails)),
+    cloudCash: Boolean(licenseKey && isCloudCashSyncEnabled(licenseDetails)),
+    cloudCredit: Boolean(licenseKey && isCloudCustomerCreditSyncEnabled(licenseDetails)),
+    cloudProducts: Boolean(licenseKey && isCloudProductsSyncEnabled(licenseDetails)),
+    online: isOnline()
+  };
+};
+
+const withCacheFallback = async ({ reportType, filters, loader, mapper }) => {
+  try {
+    const payload = await loader();
+    const mapped = mapper(payload);
+    await reportsCacheService.saveSnapshot(reportType, filters, mapped, mapped.source);
+    return mapped;
+  } catch (error) {
+    const cached = await reportsCacheService.getSnapshot(reportType, filters);
+    if (cached?.payload) {
+      const mapped = mapper(cached.payload, { stale: true });
+      mapped.source.mode = REPORT_SOURCE_MODES.CACHE;
+      mapped.source.stale = true;
+      mapped.source.warnings = Array.from(new Set([
+        'Sin conexion o servicio no disponible. Mostrando el ultimo reporte cloud guardado en este dispositivo.',
+        ...(mapped.source.warnings || [])
+      ]));
+      return mapped;
+    }
+    throw error;
+  }
+};
+
+const rowsToCsv = (rows = []) => {
+  const list = Array.isArray(rows) ? rows : [];
+  const columns = Array.from(list.reduce((set, row) => {
+    Object.keys(row || {}).forEach((key) => set.add(key));
+    return set;
+  }, new Set()));
+
+  const escape = (value) => `"${String(value ?? '').replaceAll('"', '""')}"`;
+  return [columns, ...list.map((row) => columns.map((column) => row?.[column]))]
+    .map((row) => row.map(escape).join(','))
+    .join('\n');
+};
+
+export const reportsRepository = {
+  getReportMode() {
+    const mode = getMode();
+    if (!mode.cloudReports) return { mode: REPORT_SOURCE_MODES.LOCAL, ...mode };
+    if (!mode.online) return { mode: REPORT_SOURCE_MODES.CACHE, ...mode };
+    return { mode: REPORT_SOURCE_MODES.MIXED, ...mode };
+  },
+
+  async getOverviewReport(filters = {}) {
+    const mode = getMode();
+    if (!mode.cloudReports || !mode.cloudCash || !mode.cloudCredit || !mode.cloudProducts) {
+      return reportsLocalRepository.getOverviewReport(filters);
+    }
+
+    const cloudFilters = {
+      dateFrom: filters.dateFrom || null,
+      dateTo: filters.dateTo || null,
+      scope: filters.scope || 'mine'
+    };
+
+    if (!mode.online) {
+      const cached = await reportsCacheService.getSnapshot('overview', cloudFilters);
+      if (cached?.payload) return reportsMapper.normalizeCloudOverviewAsMixed(cached.payload, { stale: true });
+      const local = await reportsLocalRepository.getOverviewReport(filters);
+      local.source.mode = REPORT_SOURCE_MODES.CACHE;
+      local.source.stale = true;
+      local.source.warnings = ['Sin conexion y sin snapshot cloud previo. Se muestran datos locales de este dispositivo.'];
+      return local;
+    }
+
+    try {
+      return await withCacheFallback({
+        reportType: 'overview',
+        filters: cloudFilters,
+        loader: () => reportsCloudRepository.getOverviewReport({ licenseKey: mode.licenseKey, ...cloudFilters }),
+        mapper: (payload) => reportsMapper.normalizeCloudOverviewAsMixed(payload)
+      });
+    } catch (error) {
+      const local = await reportsLocalRepository.getOverviewReport(filters);
+      local.source.mode = REPORT_SOURCE_MODES.MIXED;
+      local.source.warnings = [
+        'No se pudo cargar el reporte cloud. Se mantienen ventas y datos locales de este dispositivo.',
+        error?.message || 'Error desconocido'
+      ];
+      return local;
+    }
+  },
+
+  async getCashReport(filters = {}) {
+    const mode = getMode();
+    if (!mode.cloudReports || !mode.cloudCash || !mode.online) return reportsLocalRepository.getCashReport(filters);
+    return reportsMapper.normalizeReportPayload(await reportsCloudRepository.getCashReport({ licenseKey: mode.licenseKey, ...filters }));
+  },
+
+  async getCustomerCreditReport(filters = {}) {
+    const mode = getMode();
+    if (!mode.cloudReports || !mode.cloudCredit || !mode.online) return reportsLocalRepository.getCustomerCreditReport(filters);
+    return reportsMapper.normalizeReportPayload(await reportsCloudRepository.getCustomerCreditReport({ licenseKey: mode.licenseKey, ...filters }));
+  },
+
+  async getProductCatalogReport(filters = {}) {
+    const mode = getMode();
+    if (!mode.cloudReports || !mode.cloudProducts || !mode.online) return reportsLocalRepository.getProductCatalogReport(filters);
+    return reportsMapper.normalizeReportPayload(await reportsCloudRepository.getProductCatalogReport({ licenseKey: mode.licenseKey, ...filters }));
+  },
+
+  async getTimeseriesReport(filters = {}) {
+    const mode = getMode();
+    if (!mode.cloudReports || !mode.online) return reportsLocalRepository.getTimeseriesReport(filters);
+    return reportsMapper.normalizeReportPayload(await reportsCloudRepository.getTimeseriesReport({ licenseKey: mode.licenseKey, ...filters }));
+  },
+
+  async exportReportCsv(reportType, filters = {}) {
+    const mode = getMode();
+    let payload;
+
+    if (mode.cloudReports && mode.online) {
+      payload = await reportsCloudRepository.exportReportData({ licenseKey: mode.licenseKey, reportType, ...filters });
+    } else if (reportType === 'product_inventory') {
+      payload = await reportsLocalRepository.getProductCatalogReport(filters);
+      payload.rows = payload.inventory || [];
+    } else if (reportType === 'customer_debts') {
+      payload = await reportsLocalRepository.getCustomerCreditReport(filters);
+      payload.rows = payload.top_debtors || [];
+    } else {
+      payload = await reportsLocalRepository.getOverviewReport(filters);
+      payload.rows = payload.sales || [];
+    }
+
+    return {
+      success: true,
+      filename: `${reportType}-${new Date().toISOString().slice(0, 10)}.csv`,
+      csv: rowsToCsv(payload.rows || []),
+      rows: payload.rows || []
+    };
+  }
+};
+
+export default reportsRepository;


### PR DESCRIPTION
## Resumen

Implementa la base de FASE 5 — Reportes cloud PRO sin inventar ventas cloud.

### Supabase
- Se aplico migracion en el proyecto `odlrhijtfyavryeqivaa`.
- `cloud_reports_sync` queda activo solo para `pro_monthly`.
- Se crearon RPCs `security definer` para overview, caja, credito, catalogo, timeseries y exportacion plana.
- Se agregaron helpers privados para feature flag, rango de fechas, scope/staff filter y fuentes.
- Se valido que no existe `public.pos_sales`.

### Frontend
- Nueva capa `src/services/reports/` con puerta unica `reportsRepository`.
- FREE mantiene Dexie/local.
- PRO online usa reporte mixto: caja, abonos, clientes y productos cloud oficiales; ventas y mermas locales.
- PRO offline usa ultimo snapshot cacheado si existe.
- Dashboard muestra banner claro de fuente de datos.
- Dashboard escucha eventos sync de clientes, credito, caja y productos para refrescar reportes.
- Se agrega `informe_supabase_fase5_reportes_cloud.txt`.

## Importante
Ventas cloud completas NO se implementan en esta fase. No se crea `pos_sales` ni se reporta utilidad real cloud.

## Pruebas
- Migracion Supabase aplicada correctamente.
- Flag validado: PRO=true, FREE/BASIC=false.
- RPCs nuevas existen y son security definer.
- RLS activo en tablas principales.
- No se pudo ejecutar `npm run build` desde esta sesion porque no hay checkout local funcional del repo; debe correr en desarrollo/CI antes de merge.