### PR TITLE
Fix cloud cash totals for customer payments

### DIFF
--- a/src/components/caja/sections/CajaStatusCard.jsx
+++ b/src/components/caja/sections/CajaStatusCard.jsx
@@ -12,6 +12,7 @@ import {
   WalletCards
 } from 'lucide-react';
 import { Money } from '../../../utils/moneyMath';
+import { resolveCashSessionAmounts } from '../../../services/cajaProjection';
 
 const CajaStatusCard = ({
   cajaActual,
@@ -33,21 +34,16 @@ const CajaStatusCard = ({
   onResumen,
   onImprimir
 }) => {
-  let totalEnCajaSafe = Money.init(0);
-  let entradasTotalesSafe = Money.init(0);
+  const cashAmounts = cajaActual
+    ? resolveCashSessionAmounts(cajaActual, totalesTurno, { isCloudCash })
+    : null;
 
-  if (cajaActual) {
-    const inicial = Money.init(cajaActual.monto_inicial || 0);
-    const ventas = Money.init(totalesTurno.ventasContado || 0);
-    const abonos = Money.init(totalesTurno.abonosFiado || 0);
-    entradasTotalesSafe = Money.init(cajaActual.entradas_efectivo || 0);
-    const salidas = Money.init(cajaActual.salidas_efectivo || 0);
-
-    const subtotalIngresos = Money.add(inicial, ventas);
-    const subtotalExtras = Money.add(abonos, entradasTotalesSafe);
-    const ingresosTotales = Money.add(subtotalIngresos, subtotalExtras);
-    totalEnCajaSafe = Money.subtract(ingresosTotales, salidas);
-  }
+  // En cloud, Supabase es la fuente oficial de totales de caja.
+  const totalEnCajaSafe = Money.init(cashAmounts?.totalTeorico || 0);
+  const entradasTotalesSafe = Money.init(cashAmounts?.entradasEfectivo || 0);
+  const ventasTurnoSafe = Money.init(cashAmounts?.ventasContado || 0);
+  const abonosTurnoSafe = Money.init(cashAmounts?.abonosFiado || 0);
+  const salidasTotalesSafe = Money.init(cashAmounts?.salidasEfectivo || 0);
 
   const liquidityLevel = porcentajeLiquidez >= 100
     ? 'danger'
@@ -245,22 +241,22 @@ const CajaStatusCard = ({
             </button>
           </div>
           <strong className="amount neutral">
-            ${Money.toNumber(cajaActual?.monto_inicial || 0).toFixed(2)}
+            ${Money.toNumber(cashAmounts?.fondoInicial || 0).toFixed(2)}
           </strong>
         </div>
 
         <div className="cash-metric">
           <span className="cash-metric-label">Ventas en efectivo</span>
           <strong className="amount positive">
-            + ${Money.toNumber(totalesTurno.ventasContado || 0).toFixed(2)}
+            + ${Money.toNumber(ventasTurnoSafe).toFixed(2)}
           </strong>
         </div>
 
-        {Money.init(totalesTurno.abonosFiado || 0).gt(0) && (
+        {abonosTurnoSafe.gt(0) && (
           <div className="cash-metric">
             <span className="cash-metric-label">Abonos</span>
             <strong className="amount warning">
-              + ${Money.toNumber(totalesTurno.abonosFiado || 0).toFixed(2)}
+              + ${Money.toNumber(abonosTurnoSafe).toFixed(2)}
             </strong>
           </div>
         )}
@@ -275,7 +271,7 @@ const CajaStatusCard = ({
         <div className="cash-metric">
           <span className="cash-metric-label">Salidas</span>
           <strong className="amount negative">
-            - ${Money.toNumber(cajaActual?.salidas_efectivo || 0).toFixed(2)}
+            - ${Money.toNumber(salidasTotalesSafe).toFixed(2)}
           </strong>
         </div>
       </div>

--- a/src/hooks/useCaja.js
+++ b/src/hooks/useCaja.js
@@ -5,6 +5,7 @@ import { Money } from '../utils/moneyMath';
 import { MOVIMIENTO_TIPOS, CAJA_CONFIG } from '../services/cajaService';
 import { cashRepository } from '../services/cash/cashRepository';
 import { CASH_CLOUD_OFFLINE_MESSAGE } from '../services/cash/cashActor';
+import { resolveCashSessionAmounts } from '../services/cajaProjection';
 import {
   CASH_OPENING_POLICY,
   CASH_OPENING_POLICY_EVENT,
@@ -151,7 +152,15 @@ export function useCaja() {
     if (!cajaActual) return '0';
 
     const now = Date.now();
-    const totalsKey = `${totalesTurno.ventasContado}_${totalesTurno.abonosFiado}_${cajaActual.entradas_efectivo}_${cajaActual.salidas_efectivo}`;
+    const totalsKey = [
+      totalesTurno.ventasContado,
+      totalesTurno.abonosFiado,
+      cajaActual.ventas_efectivo,
+      cajaActual.abonos_fiado,
+      cajaActual.entradas_efectivo,
+      cajaActual.salidas_efectivo,
+      cajaActual.total_teorico_cloud
+    ].join('_');
 
     if (!forceRefresh
       && totalesCacheRef.current.teoricoData
@@ -161,17 +170,8 @@ export function useCaja() {
       return totalesCacheRef.current.teoricoData;
     }
 
-    const inicialSafe = Money.init(cajaActual.monto_inicial || 0);
-    const ventasSafe = Money.init(totalesTurno.ventasContado || 0);
-    const abonosSafe = Money.init(totalesTurno.abonosFiado || 0);
-    const entradasSafe = Money.init(cajaActual.entradas_efectivo || 0);
-    const salidasSafe = Money.init(cajaActual.salidas_efectivo || 0);
-
-    const totalSafe = Money.subtract(
-      Money.add(Money.add(inicialSafe, ventasSafe), Money.add(abonosSafe, entradasSafe)),
-      salidasSafe
-    );
-    const result = Money.toExactString(totalSafe);
+    // En cloud, Supabase es la fuente oficial de totales de caja.
+    const result = resolveCashSessionAmounts(cajaActual, totalesTurno, { isCloudCash }).totalTeorico;
 
     totalesCacheRef.current = {
       teoricoTimestamp: now,
@@ -181,7 +181,7 @@ export function useCaja() {
     };
 
     return result;
-  }, [cajaActual, totalesTurno]);
+  }, [cajaActual, isCloudCash, totalesTurno]);
 
   const abrirCaja = useCallback(async (openingInput = {}) => {
     if (!ensureMutableCloudCash()) return false;
@@ -429,17 +429,18 @@ export function useCaja() {
   const obtenerResumenEstadistico = useCallback(async () => {
     if (!cajaActual) return null;
 
-    const totalTeorico = Money.init(await calcularTotalTeorico());
+    const amounts = resolveCashSessionAmounts(cajaActual, totalesTurno, { isCloudCash });
+    const totalTeorico = Money.init(amounts.totalTeorico);
     const elapsedMs = Date.now() - new Date(cajaActual.fecha_apertura).getTime();
     const elapsedHours = Math.max(elapsedMs / (1000 * 60 * 60), 0.01);
     const totalIngresos = Money.add(
-      Money.init(cajaActual.monto_inicial || 0),
+      Money.init(amounts.fondoInicial),
       Money.add(
-        Money.init(totalesTurno.ventasContado || 0),
-        Money.add(Money.init(totalesTurno.abonosFiado || 0), Money.init(cajaActual.entradas_efectivo || 0))
+        Money.init(amounts.ventasContado),
+        Money.add(Money.init(amounts.abonosFiado), Money.init(amounts.entradasEfectivo))
       )
     );
-    const totalSalidas = Money.init(cajaActual.salidas_efectivo || 0);
+    const totalSalidas = Money.init(amounts.salidasEfectivo);
 
     return {
       fechaApertura: cajaActual.fecha_apertura,
@@ -452,21 +453,21 @@ export function useCaja() {
       totalIngresos: Money.toExactString(totalIngresos),
       totalSalidas: Money.toExactString(totalSalidas),
       flujoNeto: Money.toExactString(Money.subtract(totalIngresos, totalSalidas)),
-      fondoInicial: cajaActual.monto_inicial || '0',
-      ventasContado: totalesTurno.ventasContado || '0',
-      abonosFiado: totalesTurno.abonosFiado || '0',
-      entradasExtras: cajaActual.entradas_efectivo || '0',
-      ventasPorHora: Money.toExactString(Money.divide(Money.init(totalesTurno.ventasContado || 0), elapsedHours)),
-      ticketPromedioEstimado: Money.toExactString(Money.divide(Money.init(totalesTurno.ventasContado || 0), Math.max(movimientosCaja.length, 1))),
+      fondoInicial: amounts.fondoInicial,
+      ventasContado: amounts.ventasContado,
+      abonosFiado: amounts.abonosFiado,
+      entradasExtras: amounts.entradasEfectivo,
+      ventasPorHora: Money.toExactString(Money.divide(Money.init(amounts.ventasContado), elapsedHours)),
+      ticketPromedioEstimado: Money.toExactString(Money.divide(Money.init(amounts.ventasContado), Math.max(movimientosCaja.length, 1))),
       totalMovimientos: movimientosCaja.length,
       movimientosEntrada: movimientosCaja.filter((m) => ['entrada', 'ajuste_entrada'].includes(m.tipo)).length,
       movimientosSalida: movimientosCaja.filter((m) => ['salida', 'ajuste_salida'].includes(m.tipo)).length,
       alertas: {
         excesoLiquidez: totalTeorico.gt(CAJA_CONFIG.MAX_CASH_THRESHOLD),
-        salidasSignificativas: Money.init(cajaActual.salidas_efectivo || 0).gt(Money.multiply(totalIngresos, 0.3))
+        salidasSignificativas: Money.init(amounts.salidasEfectivo).gt(Money.multiply(totalIngresos, 0.3))
       }
     };
-  }, [cajaActual, calcularTotalTeorico, movimientosCaja, totalesTurno]);
+  }, [cajaActual, isCloudCash, movimientosCaja, totalesTurno]);
 
   const exportarReporteCajaCSV = useCallback(async () => {
     if (!cajaActual) return { success: false, error: 'No hay caja activa para exportar' };

--- a/src/services/__test__/cajaProjection.test.js
+++ b/src/services/__test__/cajaProjection.test.js
@@ -121,6 +121,32 @@ describe('loadCashSessionProjection', () => {
     expect(wasteWhere).toHaveBeenCalledWith('timestamp');
   });
 
+  it('mantiene calculo local desde ventas aunque la caja local tenga campos agregados locales', async () => {
+    const localSession = {
+      ...cashSession,
+      id: 'local-cash-with-fields',
+      ventas_efectivo: '0',
+      entradas_efectivo: '0',
+      salidas_efectivo: '0'
+    };
+
+    await testDb.table('sales').add({
+      id: 'local-sale-current',
+      cash_session_id: localSession.id,
+      timestamp: '2026-06-14T12:00:00.000Z',
+      status: 'closed',
+      paymentMethod: 'efectivo',
+      total: '100'
+    });
+
+    const result = await loadCashSessionProjection(testDb, localSession);
+
+    expect(result.totals).toEqual({
+      ventasContado: '100',
+      abonosFiado: '0'
+    });
+  });
+
   it('usa agregados cloud para abonos y total teorico sin duplicar movimientos customer_payment', async () => {
     const cloudSession = {
       ...cashSession,

--- a/src/services/__test__/cajaProjection.test.js
+++ b/src/services/__test__/cajaProjection.test.js
@@ -1,7 +1,7 @@
 import Dexie from 'dexie';
 import { IDBKeyRange, indexedDB } from 'fake-indexeddb';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { loadCashSessionProjection } from '../cajaProjection';
+import { loadCashSessionProjection, resolveCashSessionAmounts } from '../cajaProjection';
 
 describe('loadCashSessionProjection', () => {
   let testDb;
@@ -119,5 +119,66 @@ describe('loadCashSessionProjection', () => {
     ]);
     expect(deletedWhere).toHaveBeenCalledWith('deletedAt');
     expect(wasteWhere).toHaveBeenCalledWith('timestamp');
+  });
+
+  it('usa agregados cloud para abonos y total teorico sin duplicar movimientos customer_payment', async () => {
+    const cloudSession = {
+      ...cashSession,
+      id: 'cloud-cash-1',
+      cloudCash: true,
+      monto_inicial: '0',
+      ventas_efectivo: '0',
+      abonos_fiado: '50',
+      entradas_efectivo: '0',
+      salidas_efectivo: '0',
+      total_teorico_cloud: '50'
+    };
+
+    await testDb.table('movimientos_caja').add({
+      id: 'cloud-payment-1',
+      cash_session_id: cloudSession.id,
+      tipo: 'abono_cliente',
+      origen: 'customer_payment',
+      monto: '50',
+      fecha: '2026-06-14T12:00:00.000Z'
+    });
+
+    const result = await loadCashSessionProjection(testDb, cloudSession);
+    const amounts = resolveCashSessionAmounts(cloudSession, result.totals, { isCloudCash: true });
+
+    expect(result.totals).toEqual({
+      ventasContado: '0',
+      abonosFiado: '50'
+    });
+    expect(amounts.totalTeorico).toBe('50');
+    expect(result.movements.map((movement) => movement.id)).toContain('cloud-payment-1');
+  });
+
+  it('usa movimiento abono_cliente como fallback cloud solo si no existe agregado abonos_fiado', async () => {
+    const cloudSessionWithoutAggregate = {
+      ...cashSession,
+      id: 'cloud-cash-2',
+      cloudCash: true,
+      monto_inicial: '0',
+      ventas_efectivo: '0',
+      entradas_efectivo: '0',
+      salidas_efectivo: '0'
+    };
+
+    await testDb.table('movimientos_caja').add({
+      id: 'cloud-payment-fallback',
+      cash_session_id: cloudSessionWithoutAggregate.id,
+      tipo: 'abono_cliente',
+      origen: 'customer_payment',
+      monto: '50',
+      fecha: '2026-06-14T12:00:00.000Z'
+    });
+
+    const result = await loadCashSessionProjection(testDb, cloudSessionWithoutAggregate);
+
+    expect(result.totals).toEqual({
+      ventasContado: '0',
+      abonosFiado: '50'
+    });
   });
 });

--- a/src/services/cajaProjection.js
+++ b/src/services/cajaProjection.js
@@ -48,9 +48,7 @@ const sumCloudCustomerPaymentMovements = (movements = []) => {
 export const isCloudCashSession = (cashSession = {}, { isCloudCash = false } = {}) => Boolean(
   isCloudCash ||
   cashSession?.cloudCash ||
-  hasAmountValue(cashSession?.total_teorico_cloud) ||
-  hasAmountValue(cashSession?.ventas_efectivo) ||
-  hasAmountValue(cashSession?.abonos_fiado)
+  hasAmountValue(cashSession?.total_teorico_cloud)
 );
 
 export const buildCashSessionTotals = (cashSession = {}, salesTotals = zeroTotals, cashMovements = [], options = {}) => {

--- a/src/services/cajaProjection.js
+++ b/src/services/cajaProjection.js
@@ -2,6 +2,10 @@ import { Money } from '../utils/moneyMath';
 import { isFinanciallyClosedSale } from './sales/financialStats';
 import { STORES } from './db/dexie';
 
+const zeroTotals = { ventasContado: '0', abonosFiado: '0' };
+
+const hasAmountValue = (value) => value !== null && value !== undefined && value !== '';
+
 const sessionEnd = (cashSession, endOverride) => (
   endOverride || cashSession.fecha_cierre || new Date().toISOString()
 );
@@ -23,6 +27,87 @@ const loadSessionSales = async (database, cashSession, endOverride) => {
   ]);
 
   return [...taggedSales, ...legacySales];
+};
+
+const sumCloudCustomerPaymentMovements = (movements = []) => {
+  let total = Money.init(0);
+
+  for (const movement of movements) {
+    const type = String(movement.tipo || movement.type || '').toLowerCase();
+    const source = String(movement.origen || movement.source || '').toLowerCase();
+    const isCustomerPayment = type === 'abono_cliente' || source === 'customer_payment';
+
+    if (isCustomerPayment) {
+      total = Money.add(total, movement.monto ?? movement.amount ?? 0);
+    }
+  }
+
+  return Money.toExactString(total);
+};
+
+export const isCloudCashSession = (cashSession = {}, { isCloudCash = false } = {}) => Boolean(
+  isCloudCash ||
+  cashSession?.cloudCash ||
+  hasAmountValue(cashSession?.total_teorico_cloud) ||
+  hasAmountValue(cashSession?.ventas_efectivo) ||
+  hasAmountValue(cashSession?.abonos_fiado)
+);
+
+export const buildCashSessionTotals = (cashSession = {}, salesTotals = zeroTotals, cashMovements = [], options = {}) => {
+  const isCloud = isCloudCashSession(cashSession, options);
+  const hasCloudSales = hasAmountValue(cashSession?.ventas_efectivo);
+  const hasCloudCustomerPayments = hasAmountValue(cashSession?.abonos_fiado);
+
+  // En cloud, Supabase es la fuente oficial de totales de caja.
+  // Los movimientos se muestran para auditoria; los agregados cloud evitan doble conteo.
+  return {
+    ventasContado: isCloud && hasCloudSales
+      ? String(cashSession.ventas_efectivo)
+      : String(salesTotals?.ventasContado || '0'),
+    abonosFiado: isCloud && hasCloudCustomerPayments
+      ? String(cashSession.abonos_fiado)
+      : (isCloud ? sumCloudCustomerPaymentMovements(cashMovements) : String(salesTotals?.abonosFiado || '0'))
+  };
+};
+
+export const resolveCashSessionAmounts = (cashSession = {}, totals = zeroTotals, options = {}) => {
+  const isCloud = isCloudCashSession(cashSession, options);
+  const ventasContado = isCloud && hasAmountValue(cashSession?.ventas_efectivo)
+    ? String(cashSession.ventas_efectivo)
+    : String(totals?.ventasContado || '0');
+  const abonosFiado = isCloud && hasAmountValue(cashSession?.abonos_fiado)
+    ? String(cashSession.abonos_fiado)
+    : String(totals?.abonosFiado || '0');
+  const entradasEfectivo = String(cashSession?.entradas_efectivo || '0');
+  const salidasEfectivo = String(cashSession?.salidas_efectivo || '0');
+  const fondoInicial = String(cashSession?.monto_inicial || '0');
+
+  if (isCloud && hasAmountValue(cashSession?.total_teorico_cloud)) {
+    return {
+      fondoInicial,
+      ventasContado,
+      abonosFiado,
+      entradasEfectivo,
+      salidasEfectivo,
+      totalTeorico: String(cashSession.total_teorico_cloud),
+      source: 'cloud_aggregate'
+    };
+  }
+
+  const ingresos = Money.add(
+    Money.add(Money.init(fondoInicial), Money.init(ventasContado)),
+    Money.add(Money.init(abonosFiado), Money.init(entradasEfectivo))
+  );
+
+  return {
+    fondoInicial,
+    ventasContado,
+    abonosFiado,
+    entradasEfectivo,
+    salidasEfectivo,
+    totalTeorico: Money.toExactString(Money.subtract(ingresos, Money.init(salidasEfectivo))),
+    source: isCloud ? 'cloud_fallback' : 'local_projection'
+  };
 };
 
 export const calculateSessionTotals = (sales) => {
@@ -52,7 +137,7 @@ export const calculateSessionTotals = (sales) => {
 
 export async function loadCashSessionTotals(database, cashSession, endOverride) {
   const sales = await loadSessionSales(database, cashSession, endOverride);
-  return calculateSessionTotals(sales);
+  return buildCashSessionTotals(cashSession, calculateSessionTotals(sales));
 }
 
 const normalizeSaleMovements = (sales) => {
@@ -104,7 +189,7 @@ export async function loadCashSessionProjection(database, cashSession, endOverri
     return {
       sales: [],
       movements: [],
-      totals: { ventasContado: '0', abonosFiado: '0' }
+      totals: zeroTotals
     };
   }
 
@@ -124,6 +209,9 @@ export async function loadCashSessionProjection(database, cashSession, endOverri
       .between(cashSession.fecha_apertura, end, true, true)
       .toArray()
   ]);
+
+  const salesTotals = calculateSessionTotals(sales);
+  const totals = buildCashSessionTotals(cashSession, salesTotals, cashMovements);
 
   const movements = [
     ...cashMovements,
@@ -147,6 +235,6 @@ export async function loadCashSessionProjection(database, cashSession, endOverri
   return {
     sales,
     movements,
-    totals: calculateSessionTotals(sales)
+    totals
   };
 }


### PR DESCRIPTION
## Resumen

Corrige el descuadre donde Caja cloud mostraba movimientos `abono_cliente` en la lista, pero `Total en Caja` quedaba en `$0` porque el frontend seguía calculando totales solo desde ventas locales.

## Cambios

- Centraliza el cálculo en `resolveCashSessionAmounts` / `buildCashSessionTotals`.
- Para caja cloud usa `total_teorico_cloud` como total final cuando existe.
- Para caja cloud usa `ventas_efectivo` y `abonos_fiado` como agregados oficiales.
- Conserva los movimientos cloud en la lista solo para auditoría/visualización.
- Evita doble conteo: `abonos_fiado` tiene prioridad sobre movimientos `abono_cliente`.
- Mantiene FREE/local calculando desde ventas locales.
- Actualiza tarjeta, hook, resumen estadístico y CSV para usar la misma fórmula.

## Pruebas agregadas

- Local sigue calculando desde ventas aunque existan campos agregados locales.
- Cloud usa `abonos_fiado` y `total_teorico_cloud` sin duplicar movimientos `customer_payment`.
- Cloud usa movimiento `abono_cliente` solo como fallback si falta el agregado.

## Validación esperada

- Staff abre caja con fondo `$0`.
- Registra abono efectivo de cliente por `$50`.
- Caja muestra movimiento `$50`, total `$50`, abonos `$50`, entradas `$0`.
- Si registra entrada manual `$20`, total `$70`, abonos `$50`, entradas `$20`.
- FREE/local no cambia su comportamiento.