### PR TITLE
FASE 6B: ventas cloud con caja y folio PRO

### DIFF
--- a/informe_supabase_fase6b_ventas_cloud_caja_folio.txt
+++ b/informe_supabase_fase6b_ventas_cloud_caja_folio.txt
@@ -1,0 +1,281 @@
+INFORME SUPABASE FASE 6B — VENTAS CLOUD CON CAJA Y FOLIO
+Proyecto Supabase: odlrhijtfyavryeqivaa
+Repositorio: fdxruli/Lanzo-POS
+Rama de trabajo: fase6b-cloud-sales
+Fecha: 2026-06-25
+
+1. OBJETIVO
+Implementar la base transaccional de ventas cloud efectivas para licencias PRO, limitada a ventas pagadas/no fiadas, con folio cloud, payments, items snapshot, vínculo con caja cloud cuando aplica efectivo, auditoría e idempotencia.
+
+2. ALCANCE DE FASE 6B
+Sí hace:
+- Crea venta cloud efectiva con source_mode = cloud_committed.
+- Asigna folio cloud por licencia en formato V-000001.
+- Crea items snapshot.
+- Crea payments.
+- Valida permiso POS.
+- Valida caja cloud abierta cuando hay efectivo.
+- Crea movimiento de caja type = venta, source = sale, solo para componente efectivo.
+- Actualiza totales de caja en la misma transacción.
+- Registra auditoría de venta y caja.
+- Registra eventos en pos_sync_events para venta, items, payments, cash_movement, cash_session y report.
+- Mantiene idempotencia por licencia + key.
+- Expone repositorio/mapper/servicio frontend para pruebas controladas.
+
+No hace:
+- No descuenta pos_products.stock.
+- No descuenta pos_product_batches.stock.
+- No crea pos_customer_ledger.
+- No modifica deuda de clientes.
+- No implementa venta fiada cloud.
+- No implementa cancelaciones/devoluciones cloud.
+- No sustituye FREE/local.
+- No activa automáticamente UI sin VITE_ENABLE_CLOUD_CASHIER_SALES=true.
+
+3. TABLAS/COLUMNAS MODIFICADAS
+public.pos_sales:
+- cloud_folio text
+- folio_sequence bigint
+- cash_effect_status text
+- inventory_effect_status text default 'not_applied'
+- credit_effect_status text default 'not_applied'
+- committed_at timestamptz
+
+public.pos_cash_sessions:
+- sales_total numeric default 0
+- non_cash_sales_total numeric default 0
+- sales_count integer default 0
+- cash_sales_total ya existía y se conserva
+- expected_cash_total se conserva
+- customer_payments_total, cash_entries_total y cash_exits_total no se alteran para ventas 6B
+
+public.pos_cash_movements:
+- sale_id text null
+- type ahora permite venta
+
+public.pos_folio_sequences:
+- Nueva tabla para folios por licencia.
+- PK: (license_id, sequence_name)
+- current_value, prefix, padding, updated_at
+
+4. ÍNDICES AGREGADOS
+- idx_pos_cash_movements_license_sale_id
+- idx_pos_cash_movements_license_source_created
+- ux_pos_sales_license_cloud_folio
+- idx_pos_sales_license_source_effects_sold
+
+5. FEATURE FLAG
+Se agregó cloud_sales_cashier a public.plans.features:
+- pro_monthly: true
+- free_trial: false
+- basic_monthly: false
+
+La validación backend exige:
+- cloud_pos_sync = true
+- cloud_sales_sync_base = true
+- cloud_cash_sync = true
+- cloud_sales_cashier = true
+
+No exige todavía:
+- cloud_products_sync para inventario en venta
+- cloud_customer_credit_sync para venta fiada
+
+6. RPC CREADA
+public.pos_create_cloud_sale_cashier(
+  p_license_key text,
+  p_device_fingerprint text,
+  p_security_token text default null,
+  p_staff_session_token text default null,
+  p_sale jsonb default '{}'::jsonb,
+  p_items jsonb default '[]'::jsonb,
+  p_payments jsonb default '[]'::jsonb,
+  p_cash_session_id text default null,
+  p_idempotency_key text default null
+)
+
+Estado:
+- SECURITY DEFINER: sí.
+- Transacción lógica única: sí, al ejecutarse dentro de la función PostgreSQL.
+- Reintento idempotente: sí, devuelve response_payload si ya se completó.
+- Si está processing devuelve IDEMPOTENCY_PROCESSING.
+
+7. HELPERS PRIVADOS
+- private.assert_cloud_sales_cashier_enabled(p_context)
+- private.normalize_pos_sale_payment_method(p_method)
+- private.next_pos_sale_folio(p_license_id)
+
+next_pos_sale_folio usa pg_advisory_xact_lock por licencia + nombre de secuencia para evitar folios duplicados concurrentes.
+
+8. FLUJO DE CAJA
+Venta con efectivo:
+- Requiere caja cloud abierta del actor.
+- Staff solo usa su caja actor_key staff:<staff_user_id>.
+- Admin usa actor_key admin_device:<device_id>.
+- Inserta pos_cash_movements con:
+  type = venta
+  source = sale
+  amount = componente efectivo neto
+  sale_id = pos_sales.id
+- Actualiza pos_cash_sessions:
+  sales_total += sale.total
+  sales_count += 1
+  cash_sales_total += cash_component
+  non_cash_sales_total += non_cash_component
+  expected_cash_total += cash_component
+
+Venta tarjeta/transferencia:
+- Crea venta/items/payments.
+- No crea movimiento efectivo.
+- No incrementa expected_cash_total.
+- Si hay caja abierta del actor, puede vincular cash_session_id como contexto, pero no mueve efectivo.
+
+9. FLUJO DE FOLIO
+- Tabla: pos_folio_sequences.
+- Secuencia por license_id y sequence_name = sale.
+- Formato mínimo: V-000001, V-000002.
+- El folio se asigna una sola vez dentro de la misma transacción de commit cloud.
+
+10. IDEMPOTENCIA
+Key sugerida:
+- p_idempotency_key desde frontend, o
+- sales.cloud_commit:<local_sale_id>:<device_id>
+
+Garantías backend:
+- No duplica pos_sales por la misma key.
+- No duplica items/payments/movimiento si la key ya completó.
+- Reintento devuelve la misma respuesta guardada.
+- Movimiento de caja usa idempotency_key derivada con sufijo :cash.
+
+11. AUDITORÍA
+Se registran eventos en pos_sale_audit_events:
+- sale.cloud_committed
+- sale.cash_movement_created
+- sale.cash_session_totals_updated
+
+Payload incluye:
+- sale_id
+- folio
+- cash_session_id
+- cash_movement_id
+- actor_key/actor_name/device/staff
+- payment_summary
+- idempotency_key
+
+12. PULL/REALTIME
+Se reutilizan:
+- pos_pull_sales_snapshot
+- pos_pull_sales_changes
+- pos_get_sale
+
+Las ventas cloud_committed viajan por los mismos pull de ventas.
+Se registran eventos en pos_sync_events para:
+- sale cloud_commit
+- sale_item create
+- sale_payment create
+- cash_movement movement
+- cash_session update
+- report overview update
+
+Realtime sigue como aviso; pull incremental sigue siendo fuente oficial.
+
+13. REPORTES
+public.pos_get_reports_overview ahora incluye métricas experimentales:
+- cloud_sales_total
+- cloud_sales_count
+- cloud_cash_sales_total
+- cloud_non_cash_sales_total
+
+Advertencia agregada:
+- Ventas cloud caja 6B es experimental: no incluye utilidad final, inventario cloud ni credito cloud.
+
+No se convierte todavía utilidad real a cloud.
+
+14. INTEGRACIÓN FRONTEND
+Archivos agregados/modificados en rama fase6b-cloud-sales:
+- src/services/sync/syncConstants.js
+  - Agrega isCloudSalesCashierEnabled.
+  - Agrega operación CLOUD_COMMIT.
+
+- src/services/salesCloud/salesCloudRepository.js
+  - Agrega createCloudCashierSale(...).
+  - Agrega guard isCloudSalesCashierEnabled(...).
+
+- src/services/salesCloud/salesCloudCashierMapper.js
+  - Mapea checkout local a payload cloud cashier.
+  - Normaliza métodos cash/card/transfer/mixed.
+  - Rechaza métodos credit-like por compatibilidad.
+
+- src/services/salesCloud/salesCloudCashierService.js
+  - Decide si se puede usar cloud cashier.
+  - Requiere VITE_ENABLE_CLOUD_CASHIER_SALES=true.
+  - Requiere feature cloud_sales_cashier.
+  - Requiere conexión.
+  - Envía venta a pos_create_cloud_sale_cashier.
+  - Cachea snapshot local cloud_committed.
+  - Mapea errores técnicos a mensajes entendibles.
+
+- src/services/salesCloud/salesCloudLocalRepository.js
+  - Cachea ventas cloud_committed.
+  - Evita reintentar shadow en ventas cloud_committed.
+  - Guarda snapshot local para Dexie.
+
+- src/services/salesCloud/index.js
+  - Exporta servicios/mapper 6B.
+
+Pendiente frontend deliberado:
+- No se dejó conectado automáticamente processSaleCore.js porque el conector bloqueó la edición directa del archivo durante esta sesión.
+- La arquitectura queda lista para cablear el hook mínimo antes de executeSaleTransactionSafe:
+  1) shouldUseCloudCashierSale(...)
+  2) si true, processCloudCashierSale(...)
+  3) retornar sin llamar shadow/local para evitar doble venta.
+- Mientras ese hook no se aplique, FREE/local y PRO shadow 6A siguen igual.
+
+15. PRUEBAS REALIZADAS
+Supabase:
+- Migración aplicada correctamente.
+- pos_create_cloud_sale_cashier existe.
+- pos_create_cloud_sale_cashier es SECURITY DEFINER.
+- pos_get_reports_overview es SECURITY DEFINER.
+- private.next_pos_sale_folio existe y es SECURITY DEFINER.
+- cloud_sales_cashier quedó true solo en pro_monthly.
+- Columnas 6B existen en pos_sales, pos_cash_sessions, pos_cash_movements y pos_folio_sequences.
+
+Pendiente por ejecutar en ambiente con sesión real:
+- Venta efectivo con caja abierta.
+- Reintento misma idempotency key.
+- Venta tarjeta/transferencia.
+- Venta fiada rechazada.
+- Venta efectivo sin caja rechazada.
+- Staff intentando caja de otro staff.
+- npm run build.
+
+16. RIESGOS PENDIENTES
+- El checkout UI todavía no llama automáticamente el servicio 6B.
+- Producto/stock cloud no se descuenta hasta 6C.
+- Crédito/ledger cloud no se toca hasta 6D.
+- Si se activa VITE_ENABLE_CLOUD_CASHIER_SALES sin completar el hook de processSaleCore, no habrá cambio visible en UI.
+- La cache Dexie de venta cloud committed está preparada, pero la proyección local de inventario no debe considerarse definitiva en 6B.
+
+17. PRÓXIMOS PASOS
+6B inmediato:
+- Aplicar hook mínimo en processSaleCore.js antes de executeSaleTransactionSafe.
+- Ejecutar npm run build.
+- Probar venta efectivo/tarjeta/transferencia con una licencia PRO real.
+
+6C:
+- Inventario/lotes cloud en venta.
+- Descuento transaccional de pos_products y pos_product_batches.
+- Reservas/committed stock cloud.
+
+6D:
+- Venta fiada cloud.
+- Cargo en pos_customer_ledger.
+- Actualización de deuda cliente.
+
+6E:
+- Cancelaciones/devoluciones cloud.
+- Reversión caja/inventario/crédito.
+
+6F:
+- Migración/reportes finales.
+- Consolidación de utilidad cloud definitiva.

--- a/src/services/salesCloud/index.js
+++ b/src/services/salesCloud/index.js
@@ -1,5 +1,12 @@
 export { salesCloudRepository } from './salesCloudRepository';
 export { salesCloudLocalRepository } from './salesCloudLocalRepository';
 export { salesCloudShadowService } from './salesCloudShadowService';
+export { salesCloudCashierService } from './salesCloudCashierService';
 export { salesCloudSyncHandler, registerSalesCloudSyncHandler } from './salesCloudSyncHandler';
 export { localSaleToCloudShadowPayload, cloudSaleToLocalSyncPatch } from './salesCloudMapper';
+export {
+  normalizeCloudCashierPaymentMethod,
+  isCreditLikePaymentMethod,
+  isCloudCashierCompatiblePayment,
+  mapLocalCheckoutToCloudSale
+} from './salesCloudCashierMapper';

--- a/src/services/salesCloud/salesCloudCashierMapper.js
+++ b/src/services/salesCloud/salesCloudCashierMapper.js
@@ -1,0 +1,198 @@
+const toNumber = (value, fallback = 0) => {
+  const parsed = Number(String(value ?? '').replace(/[^0-9.-]/g, ''));
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const toIsoString = (value, fallback = new Date().toISOString()) => {
+  if (!value) return fallback;
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? fallback : date.toISOString();
+};
+
+const compactObject = (value = {}) => Object.fromEntries(
+  Object.entries(value).filter(([, entry]) => entry !== undefined && entry !== null)
+);
+
+const firstText = (...values) => {
+  for (const value of values) {
+    const text = String(value ?? '').trim();
+    if (text) return text;
+  }
+  return null;
+};
+
+export const normalizeCloudCashierPaymentMethod = (method) => {
+  const normalized = String(method || '').trim().toLowerCase();
+  if (['cash', 'efectivo'].includes(normalized)) return 'cash';
+  if (['card', 'tarjeta', 'tarjeta_credito', 'tarjeta_debito', 'credit_card', 'debit_card'].includes(normalized)) return 'card';
+  if (['transfer', 'transferencia', 'spei', 'bank_transfer'].includes(normalized)) return 'transfer';
+  if (['mixed', 'mixto'].includes(normalized)) return 'mixed';
+  if (['fiado', 'credit', 'credito', 'crédito', 'debt', 'customer_credit'].includes(normalized)) return 'credit';
+  return normalized || 'unknown';
+};
+
+export const isCreditLikePaymentMethod = (method) => (
+  normalizeCloudCashierPaymentMethod(method) === 'credit'
+);
+
+const isSupportedSingleMethod = (method) => (
+  ['cash', 'card', 'transfer'].includes(normalizeCloudCashierPaymentMethod(method))
+);
+
+export const isCloudCashierCompatiblePayment = (paymentData = {}) => {
+  const method = normalizeCloudCashierPaymentMethod(paymentData.paymentMethod);
+  if (method === 'credit') return false;
+  if (method === 'mixed') {
+    const payments = paymentData.payments || paymentData.paymentBreakdown || paymentData.paymentDetails?.payments;
+    return Array.isArray(payments) && payments.length > 1 && payments.every((payment) => isSupportedSingleMethod(payment.method || payment.paymentMethod));
+  }
+  return isSupportedSingleMethod(method);
+};
+
+const getLineTotal = (item = {}) => {
+  if (item.exactTotal !== undefined) return toNumber(item.exactTotal, 0);
+  if (item.lineTotal !== undefined) return toNumber(item.lineTotal, 0);
+  if (item.total !== undefined) return toNumber(item.total, 0);
+  return toNumber(item.price, 0) * toNumber(item.quantity, 0);
+};
+
+const mapItem = (item = {}, index = 0) => {
+  const productId = firstText(item.productId, item.product_id, item.parentId, item.id);
+  const quantity = toNumber(item.quantity, 0);
+  const unitPrice = toNumber(item.price ?? item.unitPrice ?? item.unit_price, 0);
+  const unitCost = item.cost === undefined && item.unitCost === undefined && item.unit_cost === undefined
+    ? null
+    : toNumber(item.cost ?? item.unitCost ?? item.unit_cost, 0);
+
+  return compactObject({
+    id: firstText(item.lineId, item.cartLineId) || `${productId || 'item'}:${index + 1}`,
+    product_id: productId,
+    product_name: firstText(item.name, item.productName, item.product_name) || 'Producto',
+    product_sku: firstText(item.sku, item.productSku, item.product_sku),
+    barcode: firstText(item.barcode, item.barCode),
+    category_id: firstText(item.categoryId, item.category_id),
+    category_name: firstText(item.categoryName, item.category_name, item.category, item.rubro),
+    quantity,
+    unit_price: unitPrice,
+    unit_cost: unitCost,
+    discount_amount: toNumber(item.discountAmount ?? item.discount_amount ?? item.discount, 0),
+    tax_amount: toNumber(item.taxAmount ?? item.tax_amount ?? item.tax, 0),
+    line_total: getLineTotal(item),
+    batch_id: firstText(item.batchId, item.batch_id),
+    batch_sku: firstText(item.batchSku, item.batch_sku),
+    batch_expiry_date: firstText(item.batchExpiryDate, item.batch_expiry_date, item.expiryDate),
+    rubro: firstText(item.rubro, item.categoryName, item.category),
+    metadata: compactObject({
+      parentId: item.parentId || null,
+      lineId: item.lineId || null,
+      cartLineId: item.cartLineId || null,
+      batchesUsed: item.batchesUsed || null,
+      inventoryEffectStatus: 'not_applied',
+      creditEffectStatus: 'not_applied',
+      snapshotOnly: true
+    })
+  });
+};
+
+const buildSinglePayment = ({ saleId, total, paymentData }) => {
+  const method = normalizeCloudCashierPaymentMethod(paymentData.paymentMethod);
+  const amountPaid = toNumber(paymentData.amountPaid, total);
+  const receivedAmount = method === 'cash' ? Math.max(amountPaid, total) : total;
+  const changeAmount = method === 'cash' ? Math.max(receivedAmount - total, 0) : 0;
+
+  return compactObject({
+    id: `${saleId}:payment:1`,
+    method,
+    amount: total,
+    received_amount: receivedAmount,
+    change_amount: changeAmount,
+    reference: firstText(paymentData.reference, paymentData.paymentReference),
+    metadata: {
+      source: 'cloud_cashier_checkout',
+      inventoryEffectStatus: 'not_applied',
+      creditEffectStatus: 'not_applied'
+    }
+  });
+};
+
+const buildMixedPayments = ({ saleId, paymentData }) => {
+  const payments = paymentData.payments || paymentData.paymentBreakdown || paymentData.paymentDetails?.payments || [];
+  return payments.map((payment, index) => {
+    const method = normalizeCloudCashierPaymentMethod(payment.method || payment.paymentMethod);
+    const amount = toNumber(payment.amount ?? payment.total, 0);
+    const receivedAmount = method === 'cash'
+      ? toNumber(payment.receivedAmount ?? payment.received_amount, amount)
+      : amount;
+    const changeAmount = method === 'cash'
+      ? toNumber(payment.changeAmount ?? payment.change_amount, Math.max(receivedAmount - amount, 0))
+      : 0;
+
+    return compactObject({
+      id: firstText(payment.id) || `${saleId}:payment:${index + 1}`,
+      method,
+      amount,
+      received_amount: receivedAmount,
+      change_amount: changeAmount,
+      reference: firstText(payment.reference, payment.ref),
+      metadata: {
+        ...(payment.metadata || {}),
+        source: 'cloud_cashier_checkout_mixed',
+        inventoryEffectStatus: 'not_applied',
+        creditEffectStatus: 'not_applied'
+      }
+    });
+  });
+};
+
+export const mapLocalCheckoutToCloudSale = ({ sale = {}, processedItems = [], paymentData = {}, total = null } = {}) => {
+  const now = new Date().toISOString();
+  const saleId = sale.id || `sal_${Date.now()}`;
+  const totalNumber = toNumber(total ?? sale.total, 0);
+  const method = normalizeCloudCashierPaymentMethod(paymentData.paymentMethod || sale.paymentMethod);
+  const payments = method === 'mixed'
+    ? buildMixedPayments({ saleId, paymentData })
+    : [buildSinglePayment({ saleId, total: totalNumber, paymentData })];
+  const paymentSum = payments.reduce((sum, payment) => sum + toNumber(payment.amount, 0), 0);
+
+  return {
+    sale: compactObject({
+      id: saleId,
+      local_sale_id: saleId,
+      sold_at: toIsoString(sale.timestamp || sale.soldAt || sale.sold_at, now),
+      created_at: toIsoString(sale.createdAt || sale.created_at || sale.timestamp, now),
+      status: 'closed',
+      fulfillment_status: sale.fulfillmentStatus || sale.fulfillment_status || null,
+      payment_method: method,
+      payment_status: 'paid',
+      customer_id: firstText(paymentData.customerId, sale.customerId, sale.customer_id),
+      customer_name: firstText(sale.customerName, sale.customer?.name, sale.customerSnapshot?.name),
+      customer_phone: firstText(sale.customerPhone, sale.customer?.phone, sale.customerSnapshot?.phone),
+      subtotal: toNumber(sale.subtotal, totalNumber),
+      discount_total: toNumber(sale.discountTotal ?? sale.discount_total, 0),
+      tax_total: toNumber(sale.taxTotal ?? sale.tax_total, 0),
+      total: totalNumber,
+      amount_paid: paymentSum,
+      change_amount: payments.reduce((sum, payment) => sum + toNumber(payment.change_amount, 0), 0),
+      balance_due: 0,
+      currency: sale.currency || 'MXN',
+      metadata: compactObject({
+        phase: 'fase6b_cloud_cashier_sales',
+        localGeneratedAt: now,
+        orderType: sale.orderType || null,
+        splitGroupId: sale.splitGroupId || null,
+        noCloudInventoryEffects: true,
+        noCloudCreditEffects: true
+      })
+    }),
+    items: (Array.isArray(processedItems) ? processedItems : []).map(mapItem),
+    payments,
+    idempotencyKey: `sales.cloud_commit:${saleId}`
+  };
+};
+
+export default {
+  normalizeCloudCashierPaymentMethod,
+  isCreditLikePaymentMethod,
+  isCloudCashierCompatiblePayment,
+  mapLocalCheckoutToCloudSale
+};

--- a/src/services/salesCloud/salesCloudCashierService.js
+++ b/src/services/salesCloud/salesCloudCashierService.js
@@ -1,0 +1,134 @@
+import Logger from '../Logger';
+import { getStableDeviceId } from '../supabase';
+import { useAppStore } from '../../store/useAppStore';
+import { getLicenseKeyFromDetails, isCloudSalesCashierEnabled } from '../sync/syncConstants';
+import { salesCloudRepository } from './salesCloudRepository';
+import { salesCloudLocalRepository } from './salesCloudLocalRepository';
+import {
+  isCloudCashierCompatiblePayment,
+  isCreditLikePaymentMethod,
+  mapLocalCheckoutToCloudSale
+} from './salesCloudCashierMapper';
+
+const isOnline = () => typeof navigator === 'undefined' || navigator.onLine !== false;
+
+const isExperimentalFlagEnabled = () => {
+  try {
+    return import.meta.env?.VITE_ENABLE_CLOUD_CASHIER_SALES === 'true';
+  } catch {
+    return false;
+  }
+};
+
+const getRuntimeContext = async () => {
+  const state = useAppStore.getState();
+  const licenseDetails = state?.licenseDetails || null;
+  const licenseKey = getLicenseKeyFromDetails(licenseDetails);
+  const deviceId = await getStableDeviceId().catch(() => 'device');
+
+  return {
+    licenseDetails,
+    licenseKey,
+    deviceId,
+    online: isOnline(),
+    featureEnabled: Boolean(licenseKey && isCloudSalesCashierEnabled(licenseDetails)),
+    experimentalEnabled: isExperimentalFlagEnabled()
+  };
+};
+
+const friendlyCloudCashierError = (error) => {
+  const raw = String(error?.message || error?.code || error || '');
+  const code = raw.match(/[A-Z0-9_]+(?::[a-z_]+)?/)?.[0] || raw;
+
+  const messages = {
+    CLOUD_CASH_SESSION_REQUIRED: 'Para cobrar esta venta en cloud necesitas abrir caja primero.',
+    CASH_SESSION_NOT_OPEN: 'La caja seleccionada ya no está abierta. Revisa Caja e intenta de nuevo.',
+    CASH_SESSION_FORBIDDEN: 'Esta caja pertenece a otro usuario o dispositivo.',
+    SALE_CREDIT_NOT_IMPLEMENTED_IN_6B: 'La venta fiada seguirá en modo local por ahora. Crédito cloud se activará en Fase 6D.',
+    SALE_PAYMENT_TOTAL_MISMATCH: 'Los pagos no cuadran con el total de la venta. Revisa el cobro antes de intentarlo de nuevo.',
+    IDEMPOTENCY_PROCESSING: 'La venta ya está en proceso. Evita presionar cobrar otra vez.',
+    CLOUD_SALES_CASHIER_DISABLED: 'Venta cloud con caja aún no está activa para esta licencia.',
+    POS_SYNC_AUTH_CONTEXT_INCOMPLETE: 'No se pudo validar la licencia de este dispositivo. Revisa conexión y licencia.'
+  };
+
+  const friendly = messages[code] || messages[raw] || raw || 'No se pudo confirmar la venta cloud.';
+  const mapped = new Error(friendly);
+  mapped.code = code;
+  mapped.originalError = error;
+  return mapped;
+};
+
+export const salesCloudCashierService = {
+  async canUseCloudCashierSale(licenseDetails = null) {
+    const context = await getRuntimeContext();
+    const details = licenseDetails || context.licenseDetails;
+    return Boolean(
+      context.online &&
+      context.experimentalEnabled &&
+      context.licenseKey &&
+      isCloudSalesCashierEnabled(details)
+    );
+  },
+
+  async shouldUseCloudCashierSale({ paymentData = {}, cart = [], licenseDetails = null } = {}) {
+    const context = await getRuntimeContext();
+    const details = licenseDetails || context.licenseDetails;
+
+    if (!context.experimentalEnabled) return { useCloud: false, reason: 'experimental_flag_disabled' };
+    if (!context.online) return { useCloud: false, reason: 'offline_local_shadow' };
+    if (!context.licenseKey || !isCloudSalesCashierEnabled(details)) return { useCloud: false, reason: 'feature_disabled' };
+    if (!Array.isArray(cart) || cart.length === 0) return { useCloud: false, reason: 'empty_cart' };
+    if (isCreditLikePaymentMethod(paymentData.paymentMethod)) return { useCloud: false, reason: 'credit_deferred_to_6d' };
+    if (!isCloudCashierCompatiblePayment(paymentData)) return { useCloud: false, reason: 'payment_not_compatible' };
+
+    return { useCloud: true, reason: 'cloud_cashier_enabled', context };
+  },
+
+  async processCloudCashierSale({ sale, processedItems = [], paymentData = {}, total, licenseDetails = null } = {}) {
+    const context = await getRuntimeContext();
+    const details = licenseDetails || context.licenseDetails;
+
+    if (!context.online) throw friendlyCloudCashierError(new Error('OFFLINE'));
+    if (!context.experimentalEnabled || !context.licenseKey || !isCloudSalesCashierEnabled(details)) {
+      throw friendlyCloudCashierError(new Error('CLOUD_SALES_CASHIER_DISABLED'));
+    }
+
+    const payload = mapLocalCheckoutToCloudSale({ sale, processedItems, paymentData, total });
+    const idempotencyKey = `${payload.idempotencyKey}:${context.deviceId}`;
+
+    try {
+      const response = await salesCloudRepository.createCloudCashierSale({
+        licenseKey: context.licenseKey,
+        ...payload,
+        cashSessionId: paymentData.cashSessionId || paymentData.cash_session_id || null,
+        idempotencyKey
+      });
+
+      if (response?.success === false) {
+        const error = new Error(response.message || response.code || 'CLOUD_CASHIER_SALE_FAILED');
+        error.code = response.code;
+        throw error;
+      }
+
+      const localSale = await salesCloudLocalRepository.saveCloudCommittedSaleSnapshot({
+        localSale: {
+          ...sale,
+          items: processedItems,
+          syncStatus: 'SYNCED',
+          cloudSalesSyncStatus: 'synced',
+          sourceMode: 'cloud_committed',
+          effectsStatus: response.sale?.effects_status || 'payment_recorded'
+        },
+        response
+      });
+
+      await salesCloudLocalRepository.applyCloudSalesPayload(response);
+      return { success: true, response, localSale, payload, idempotencyKey };
+    } catch (error) {
+      Logger.error('[SalesCloud/Cashier] Venta cloud no confirmada:', error);
+      throw friendlyCloudCashierError(error);
+    }
+  }
+};
+
+export default salesCloudCashierService;

--- a/src/services/salesCloud/salesCloudLocalRepository.js
+++ b/src/services/salesCloud/salesCloudLocalRepository.js
@@ -1,7 +1,8 @@
 import { db, STORES } from '../db/dexie';
+import { generateID } from '../utils';
 import { cloudSaleToLocalSyncPatch } from './salesCloudMapper';
 
-const CLOUD_SALE_CACHE_PREFIX = 'cloud_sale_shadow:';
+const CLOUD_SALE_CACHE_PREFIX = 'cloud_sale:';
 const nowIso = () => new Date().toISOString();
 
 const ensureOpen = async () => {
@@ -13,6 +14,7 @@ const stringifyError = (error) => (
 );
 
 const getLocalSaleId = (cloudSale = {}) => cloudSale.local_sale_id || cloudSale.localSaleId || cloudSale.id || null;
+const isCloudCommitted = (sale = {}) => (sale.source_mode || sale.sourceMode) === 'cloud_committed';
 
 const upsertCloudSaleCache = async ({ sale, items = [], payments = [] }) => {
   if (!sale?.id) return null;
@@ -24,7 +26,7 @@ const upsertCloudSaleCache = async ({ sale, items = [], payments = [] }) => {
       items,
       payments,
       cachedAt: nowIso(),
-      phase: 'fase6a_sales_cloud_base'
+      phase: isCloudCommitted(sale) ? 'fase6b_cloud_cashier_sales' : 'fase6a_sales_cloud_base'
     },
     updatedAt: nowIso()
   };
@@ -33,12 +35,42 @@ const upsertCloudSaleCache = async ({ sale, items = [], payments = [] }) => {
   return row;
 };
 
+const buildLocalCloudCommittedSale = ({ localSale = {}, cloudSale = {}, items = [], response = {} }) => ({
+  ...localSale,
+  id: localSale.id || cloudSale.local_sale_id || cloudSale.id,
+  timestamp: cloudSale.sold_at || cloudSale.soldAt || localSale.timestamp || nowIso(),
+  soldAt: cloudSale.sold_at || cloudSale.soldAt || localSale.soldAt || null,
+  items: Array.isArray(localSale.items) && localSale.items.length > 0 ? localSale.items : items,
+  total: String(cloudSale.total ?? localSale.total ?? 0),
+  paymentMethod: cloudSale.payment_method || localSale.paymentMethod,
+  abono: String(cloudSale.amount_paid ?? localSale.abono ?? cloudSale.total ?? 0),
+  saldoPendiente: String(cloudSale.balance_due ?? 0),
+  status: cloudSale.status || localSale.status || 'closed',
+  folio: cloudSale.cloud_folio || cloudSale.folio || localSale.folio,
+  cloudFolio: cloudSale.cloud_folio || null,
+  cloudSaleId: cloudSale.id || response.sale?.id || null,
+  cloudSalesSyncStatus: 'synced',
+  cloudSalesLastSyncAt: nowIso(),
+  cloudSalesSyncError: null,
+  cloudServerVersion: Number(cloudSale.server_version || response.server_version || 0) || null,
+  sourceMode: cloudSale.source_mode || 'cloud_committed',
+  effectsStatus: cloudSale.effects_status || 'payment_recorded',
+  cashSessionId: cloudSale.cash_session_id || null,
+  cashMovementId: cloudSale.cash_movement_id || null,
+  cashEffectStatus: cloudSale.cash_effect_status || null,
+  inventoryEffectStatus: cloudSale.inventory_effect_status || 'not_applied',
+  creditEffectStatus: cloudSale.credit_effect_status || 'not_applied',
+  committedAt: cloudSale.committed_at || null,
+  postEffectsCompleted: false,
+  syncStatus: 'SYNCED'
+});
+
 export const salesCloudLocalRepository = {
   async markShadowPending(saleId, { reason = 'pending_shadow_sync' } = {}) {
     if (!saleId) return null;
     await ensureOpen();
     const existing = await db.table(STORES.SALES).get(saleId);
-    if (!existing) return null;
+    if (!existing || existing.sourceMode === 'cloud_committed') return null;
 
     const patch = {
       cloudSalesSyncStatus: 'pending',
@@ -56,7 +88,7 @@ export const salesCloudLocalRepository = {
     if (!saleId) return null;
     await ensureOpen();
     const existing = await db.table(STORES.SALES).get(saleId);
-    if (!existing) return null;
+    if (!existing || existing.sourceMode === 'cloud_committed') return null;
 
     const patch = {
       cloudSalesSyncStatus: 'failed',
@@ -74,11 +106,38 @@ export const salesCloudLocalRepository = {
     if (!localSaleId) return null;
     await ensureOpen();
     const existing = await db.table(STORES.SALES).get(localSaleId);
-    if (!existing) return null;
+    if (!existing || existing.sourceMode === 'cloud_committed') return null;
 
     const patch = cloudSaleToLocalSyncPatch(response.sale || {}, response);
     await db.table(STORES.SALES).update(localSaleId, patch);
     return { ...existing, ...patch };
+  },
+
+  async saveCloudCommittedSaleSnapshot({ localSale = {}, response = {} } = {}) {
+    await ensureOpen();
+    const cloudSale = response.sale || {};
+    const saleId = localSale.id || cloudSale.local_sale_id || cloudSale.id;
+    if (!saleId || !cloudSale.id) return null;
+
+    const items = Array.isArray(response.items) ? response.items : [];
+    const localSnapshot = buildLocalCloudCommittedSale({ localSale, cloudSale, items, response });
+
+    await db.transaction('rw', [db.table(STORES.SALES), db.table(STORES.TRANSACTION_LOG)], async () => {
+      await db.table(STORES.SALES).put(localSnapshot);
+      await db.table(STORES.TRANSACTION_LOG).put({
+        id: generateID('txn'),
+        type: 'CLOUD_SALE',
+        status: 'COMPLETED',
+        timestamp: nowIso(),
+        amount: localSnapshot.total,
+        saleId,
+        cloudSaleId: cloudSale.id,
+        folio: localSnapshot.folio,
+        sourceMode: 'cloud_committed'
+      });
+    });
+
+    return localSnapshot;
   },
 
   async getSaleById(saleId) {
@@ -94,14 +153,14 @@ export const salesCloudLocalRepository = {
       const pending = await db.table(STORES.SALES)
         .where('cloudSalesSyncStatus')
         .anyOf(['pending', 'failed'])
-        .filter((sale) => sale?.status !== 'open')
+        .filter((sale) => sale?.status !== 'open' && sale?.sourceMode !== 'cloud_committed')
         .limit(limit)
         .toArray();
 
       return pending;
     } catch {
       return db.table(STORES.SALES)
-        .filter((sale) => ['pending', 'failed'].includes(sale?.cloudSalesSyncStatus) && sale?.status !== 'open')
+        .filter((sale) => ['pending', 'failed'].includes(sale?.cloudSalesSyncStatus) && sale?.status !== 'open' && sale?.sourceMode !== 'cloud_committed')
         .limit(limit)
         .toArray();
     }
@@ -125,6 +184,7 @@ export const salesCloudLocalRepository = {
 
       const localSale = await db.table(STORES.SALES).get(localSaleId);
       if (!localSale) continue;
+      if (localSale.sourceMode === 'cloud_committed' && isCloudCommitted(sale)) continue;
 
       await db.table(STORES.SALES).update(localSaleId, cloudSaleToLocalSyncPatch(sale, response));
       patchedLocal += 1;

--- a/src/services/salesCloud/salesCloudRepository.js
+++ b/src/services/salesCloud/salesCloudRepository.js
@@ -1,6 +1,6 @@
 import { supabaseClient } from '../supabase';
 import { buildPosSyncAuthContext } from '../sync/posSyncClient';
-import { isCloudSalesBaseSyncEnabled, SYNC_LIMITS } from '../sync/syncConstants';
+import { isCloudSalesBaseSyncEnabled, isCloudSalesCashierEnabled, SYNC_LIMITS } from '../sync/syncConstants';
 
 const parseRpcPayload = (data) => {
   if (typeof data === 'string') return JSON.parse(data);
@@ -38,6 +38,10 @@ export const salesCloudRepository = {
     return isCloudSalesBaseSyncEnabled(licenseDetails);
   },
 
+  isCloudSalesCashierEnabled(licenseDetails = {}) {
+    return isCloudSalesCashierEnabled(licenseDetails);
+  },
+
   async upsertSaleShadow({ licenseKey, sale, items = [], payments = [], idempotencyKey }) {
     assertSupabase();
     const baseArgs = await buildBaseRpcArgs(licenseKey);
@@ -47,6 +51,30 @@ export const salesCloudRepository = {
       p_sale: sale || {},
       p_items: Array.isArray(items) ? items : [],
       p_payments: Array.isArray(payments) ? payments : [],
+      p_idempotency_key: idempotencyKey || null
+    });
+
+    if (error) throw error;
+    return parseRpcPayload(data);
+  },
+
+  async createCloudCashierSale({
+    licenseKey,
+    sale,
+    items = [],
+    payments = [],
+    cashSessionId = null,
+    idempotencyKey = null
+  }) {
+    assertSupabase();
+    const baseArgs = await buildBaseRpcArgs(licenseKey);
+
+    const { data, error } = await supabaseClient.rpc('pos_create_cloud_sale_cashier', {
+      ...baseArgs,
+      p_sale: sale || {},
+      p_items: Array.isArray(items) ? items : [],
+      p_payments: Array.isArray(payments) ? payments : [],
+      p_cash_session_id: cashSessionId || null,
       p_idempotency_key: idempotencyKey || null
     });
 

--- a/src/services/sync/syncConstants.js
+++ b/src/services/sync/syncConstants.js
@@ -51,6 +51,7 @@ export const SYNC_OPERATIONS = Object.freeze({
   RESTORE: 'restore',
   UPSERT: 'upsert',
   UPSERT_SHADOW: 'upsert_shadow',
+  CLOUD_COMMIT: 'cloud_commit',
   PULL_SNAPSHOT: 'pull_snapshot',
   PULL_CHANGES: 'pull_changes',
   TOGGLE_STATUS: 'toggle_status',
@@ -116,6 +117,14 @@ export const isCloudCustomerCreditSyncEnabled = (licenseDetails = {}) => {
 export const isCloudSalesBaseSyncEnabled = (licenseDetails = {}) => {
   const features = getPlanFeaturesFromLicenseDetails(licenseDetails);
   return isFeatureEnabled(features, 'cloud_pos_sync') && isFeatureEnabled(features, 'cloud_sales_sync_base');
+};
+
+export const isCloudSalesCashierEnabled = (licenseDetails = {}) => {
+  const features = getPlanFeaturesFromLicenseDetails(licenseDetails);
+  return isFeatureEnabled(features, 'cloud_pos_sync')
+    && isFeatureEnabled(features, 'cloud_sales_sync_base')
+    && isFeatureEnabled(features, 'cloud_cash_sync')
+    && isFeatureEnabled(features, 'cloud_sales_cashier');
 };
 
 export const getLicenseKeyFromDetails = (licenseDetails = {}) => (


### PR DESCRIPTION
## Resumen

Implementa la base de FASE 6B para ventas cloud efectivas PRO:

- RPC/backend Supabase aplicado: `pos_create_cloud_sale_cashier`.
- Folio cloud por licencia con `pos_folio_sequences`.
- Movimiento de caja solo para componente efectivo.
- Totales de caja separados: total ventas, efectivo, no efectivo, conteo.
- Métricas experimentales de ventas cloud en `pos_get_reports_overview`.
- Servicios frontend preparados detrás de `VITE_ENABLE_CLOUD_CASHIER_SALES=true`.
- Informe agregado: `informe_supabase_fase6b_ventas_cloud_caja_folio.txt`.

## Importante

Backend Supabase ya quedó aplicado y verificado.

El hook automático en `processSaleCore.js` queda pendiente porque el conector bloqueó la edición directa de ese archivo durante esta sesión. Por seguridad, esta rama deja los servicios listos pero no fuerza activación automática del checkout.

## Pendiente antes de merge productivo

- Conectar `salesCloudCashierService.shouldUseCloudCashierSale(...)` antes de `executeSaleTransactionSafe(...)` en `processSaleCore.js`.
- Ejecutar `npm run build`.
- Probar con licencia PRO real:
  - venta efectivo con caja abierta;
  - reintento misma idempotency key;
  - venta tarjeta/transferencia;
  - fiado rechazado;
  - efectivo sin caja rechazado;
  - staff sin acceso a caja de otro staff.

## Seguridad de alcance

- No descuenta inventario cloud.
- No toca crédito/ledger cloud.
- No cambia FREE/local.
- Shadow 6A sigue separado de ventas cloud_committed.