### PR TITLE
FASE 6H.2 — Realtime adaptativo y reconexión inteligente

### DIFF
--- a/src/services/licenseRealtime.js
+++ b/src/services/licenseRealtime.js
@@ -1,5 +1,9 @@
 import { supabaseClient } from './supabase';
 import Logger from './Logger';
+import {
+  REALTIME_FORCE_VALIDATE_AFTER_OFFLINE_MS,
+  REALTIME_SHORT_RECONNECT_GRACE_MS
+} from '../store/slices/license/licenseConstants';
 
 let activeChannel = null;
 let reconnectTimer = null;
@@ -7,6 +11,10 @@ let isConnecting = false;
 let isReconnecting = false;
 let reconnectAttempts = 0;
 let onlineListener = null;
+
+let hasEverSubscribed = false;
+let lastDisconnectedAt = 0;
+let lastSubscribedAt = 0;
 
 const closingChannels = new WeakSet();
 const handledClosedChannels = new WeakSet();
@@ -31,12 +39,44 @@ const DEVICE_EVENTS = new Set([
   'DEVICE_RELEASED'
 ]);
 
-const reportRealtimeFallbackOnce = (callbacks = {}, message) => {
+const resetRealtimeConnectionState = () => {
+  hasEverSubscribed = false;
+  lastDisconnectedAt = 0;
+  lastSubscribedAt = 0;
+};
+
+const markRealtimeDisconnected = () => {
+  if (!lastDisconnectedAt) {
+    lastDisconnectedAt = Date.now();
+  }
+
+  return lastDisconnectedAt;
+};
+
+const buildReconnectMetadata = (topic) => {
+  const subscribedAt = Date.now();
+  const disconnectedDurationMs = lastDisconnectedAt > 0
+    ? Math.max(0, subscribedAt - lastDisconnectedAt)
+    : 0;
+  const wasLongDisconnect = disconnectedDurationMs >= REALTIME_FORCE_VALIDATE_AFTER_OFFLINE_MS;
+  const wasShortReconnect = disconnectedDurationMs > 0 && disconnectedDurationMs <= REALTIME_SHORT_RECONNECT_GRACE_MS;
+
+  return {
+    reason: wasShortReconnect ? 'resubscribed' : 'reconnected',
+    subscribedAt,
+    topic,
+    disconnectedDurationMs,
+    wasLongDisconnect
+  };
+};
+
+const reportRealtimeFallbackOnce = (callbacks = {}, message, metadata = {}) => {
   if (realtimeFallbackReported) return;
 
   realtimeFallbackReported = true;
   callbacks.onPermanentFailure?.(
-    message || 'La conexión en tiempo real se interrumpió. Lanzo POS seguirá funcionando en modo híbrido.'
+    message || 'La conexión en tiempo real se interrumpió. Lanzo POS seguirá funcionando en modo híbrido.',
+    metadata
   );
 };
 
@@ -49,7 +89,8 @@ export const startLicenseListener = (licenseKey, deviceFingerprint, realtimeTopi
   if (!supabaseClient) {
     Logger.warn('[Realtime] Supabase no esta configurado. Usando fallback hibrido.');
     callbacks.onPermanentFailure?.(
-      'Realtime no esta disponible. Se trabajara con sincronizacion hibrida.'
+      'Realtime no esta disponible. Se trabajara con sincronizacion hibrida.',
+      { permanent: true, reason: 'supabase_not_configured' }
     );
     return null;
   }
@@ -65,6 +106,12 @@ export const startLicenseListener = (licenseKey, deviceFingerprint, realtimeTopi
 
   if (!navigator.onLine) {
     Logger.warn('[Realtime] Sin conexión. Realtime queda en espera hasta recuperar red.');
+    markRealtimeDisconnected();
+    callbacks.onDisconnected?.({
+      reason: 'disconnected',
+      disconnectedAt: lastDisconnectedAt,
+      topic: realtimeTopic
+    });
     handleReconnect(licenseKey, deviceFingerprint, realtimeTopic, callbacks);
     return null;
   }
@@ -122,16 +169,46 @@ export const startLicenseListener = (licenseKey, deviceFingerprint, realtimeTopi
     })
     .subscribe((status, err) => {
       if (status === 'SUBSCRIBED') {
-        Logger.log('[Realtime] Canal privado conectado.');
+        const subscribedAt = Date.now();
+        const isInitialSubscription = !hasEverSubscribed;
+        const metadata = buildReconnectMetadata(realtimeTopic);
+
+        Logger.log(
+          isInitialSubscription
+            ? '[Realtime] Canal conectado inicialmente; sin validación remota forzada.'
+            : `[Realtime] Canal reconectado (${metadata.reason}) tras ${Math.round(metadata.disconnectedDurationMs / 1000)}s.`
+        );
+
         isConnecting = false;
         isReconnecting = false;
         activeChannel = channel;
         reconnectAttempts = 0;
         realtimeFallbackReported = false;
+        lastSubscribedAt = subscribedAt;
+        hasEverSubscribed = true;
+        lastDisconnectedAt = 0;
+
         if (reconnectTimer) clearTimeout(reconnectTimer);
-        callbacks.onConnectionRestored?.();
+
+        if (isInitialSubscription) {
+          callbacks.onInitialSubscribed?.({
+            subscribedAt,
+            topic: realtimeTopic
+          });
+          return;
+        }
+
+        callbacks.onConnectionRestored?.(metadata);
       } else if (status === 'CHANNEL_ERROR' || status === 'TIMED_OUT') {
+        const reason = status === 'TIMED_OUT' ? 'timed_out' : 'channel_error';
+        markRealtimeDisconnected();
+
         Logger.error('[Realtime] Error de conexion:', err || status);
+        callbacks.onDisconnected?.({
+          reason,
+          disconnectedAt: lastDisconnectedAt,
+          topic: realtimeTopic
+        });
         isConnecting = false;
 
         supabaseClient.removeChannel(channel).catch(() => { });
@@ -158,11 +235,19 @@ export const startLicenseListener = (licenseKey, deviceFingerprint, realtimeTopi
         }
 
         if (!wasManualClose) {
+          markRealtimeDisconnected();
+          callbacks.onDisconnected?.({
+            reason: 'disconnected',
+            disconnectedAt: lastDisconnectedAt,
+            topic: realtimeTopic
+          });
+
           Logger.warn('[Realtime] Canal cerrado inesperadamente. Usando fallback/reintento.');
 
           reportRealtimeFallbackOnce(
             callbacks,
-            'La conexión en tiempo real se interrumpió. Lanzo POS seguirá funcionando en modo híbrido.'
+            'La conexión en tiempo real se interrumpió. Lanzo POS seguirá funcionando en modo híbrido.',
+            { permanent: false, reason: 'channel_closed' }
           );
 
           handleReconnect(licenseKey, deviceFingerprint, realtimeTopic, callbacks);
@@ -177,6 +262,7 @@ const handleReconnect = (key, fp, topic, callbacks = {}) => {
   if (reconnectTimer || isReconnecting) return;
 
   if (!navigator.onLine) {
+    markRealtimeDisconnected();
     Logger.log('[Realtime] Red caida. Esperando reconexion del sistema operativo.');
     isReconnecting = true;
 
@@ -196,7 +282,8 @@ const handleReconnect = (key, fp, topic, callbacks = {}) => {
     window.addEventListener('online', onlineListener);
     reportRealtimeFallbackOnce(
       callbacks,
-      'Conexión perdida. Lanzo POS trabajará offline hasta que regrese internet.'
+      'Conexión perdida. Lanzo POS trabajará offline hasta que regrese internet.',
+      { permanent: false, reason: 'offline' }
     );
     return;
   }
@@ -219,7 +306,8 @@ const handleReconnect = (key, fp, topic, callbacks = {}) => {
     Logger.error('[Realtime] Sin conexion tras maximos reintentos. Modo hibrido.');
     reportRealtimeFallbackOnce(
       callbacks,
-      'No se pudo establecer conexión en tiempo real con el servidor. Se trabajará en modo híbrido.'
+      'No se pudo establecer conexión en tiempo real con el servidor. Se trabajará en modo híbrido.',
+      { permanent: true, reason: 'max_reconnect_attempts' }
     );
   }
 };
@@ -249,6 +337,7 @@ export const stopLicenseListener = async (channel) => {
     }
   }
   if (activeChannel === channel) activeChannel = null;
+  resetRealtimeConnectionState();
 };
 
 export const cleanupAllChannels = async () => {
@@ -258,5 +347,8 @@ export const cleanupAllChannels = async () => {
 export const getConnectionStatus = () => ({
   isActive: activeChannel !== null,
   isConnecting,
-  isReconnecting
+  isReconnecting,
+  hasEverSubscribed,
+  lastDisconnectedAt,
+  lastSubscribedAt
 });

--- a/src/services/licenseRealtime.js
+++ b/src/services/licenseRealtime.js
@@ -71,7 +71,9 @@ const buildReconnectMetadata = (topic) => {
 };
 
 const reportRealtimeFallbackOnce = (callbacks = {}, message, metadata = {}) => {
-  if (realtimeFallbackReported) return;
+  const isPermanentFailure = metadata.permanent === true;
+
+  if (realtimeFallbackReported && !isPermanentFailure) return;
 
   realtimeFallbackReported = true;
   callbacks.onPermanentFailure?.(

--- a/src/store/slices/license/licenseConstants.js
+++ b/src/store/slices/license/licenseConstants.js
@@ -88,6 +88,12 @@ export const LICENSE_VALIDATION_ERROR_COOLDOWN_MS = 10 * 60 * 1000; // 10 min
 // Evita stop/start de realtime en cada regreso a primer plano si el canal sigue vivo.
 export const REALTIME_RECOVERY_MIN_INTERVAL_MS = 5 * 60 * 1000;
 
+// FASE 6H.2: reconexión realtime adaptativa.
+// Microcortes cortos no deben convertir SUBSCRIBED en validación remota crítica.
+export const REALTIME_SHORT_RECONNECT_GRACE_MS = 2 * 60 * 1000; // 2 min
+// Si la app/canal estuvo fuera suficiente tiempo, se valida remoto al regresar.
+export const REALTIME_FORCE_VALIDATE_AFTER_OFFLINE_MS = 15 * 60 * 1000; // 15 min
+
 // Perfil: TTL largo. No se refresca en ventas ni safety checks frecuentes.
 export const PROFILE_REFRESH_TTL_MS = 12 * 60 * 60 * 1000;
 export const PROFILE_LAST_LOAD_KEY = 'Lanzo_last_profile_load';

--- a/src/store/slices/license/licenseGuards.js
+++ b/src/store/slices/license/licenseGuards.js
@@ -23,9 +23,9 @@ import {
   shouldSkipRemoteValidationForPlan as shouldSkipRemoteValidationForPlanFromTimestamps
 } from './licenseValidationTimestamps';
 
-const CRITICAL_LICENSE_VALIDATION_REASONS = [
+const CRITICAL_LICENSE_VALIDATION_REASONS = new Set([
   'realtime_event',
-  'realtime_reconnected',
+  'realtime_reconnected_long',
   'realtime_recover',
   'license_changed',
   'plan_changed',
@@ -38,6 +38,10 @@ const CRITICAL_LICENSE_VALIDATION_REASONS = [
   'activation',
   'staff_login',
   'renewal'
+]);
+
+const CRITICAL_LICENSE_VALIDATION_REASON_PREFIXES = [
+  'realtime_recover_'
 ];
 
 const normalizePlanCode = (licenseDetails = {}) => (
@@ -88,7 +92,9 @@ export const getLicenseSyncIntervalMs = (licenseDetails = {}, mode = getLicenseS
 
 export const isCriticalLicenseValidationReason = (reason = '') => {
   const normalized = String(reason || '').toLowerCase();
-  return CRITICAL_LICENSE_VALIDATION_REASONS.some((item) => normalized.includes(item));
+
+  return CRITICAL_LICENSE_VALIDATION_REASONS.has(normalized) ||
+    CRITICAL_LICENSE_VALIDATION_REASON_PREFIXES.some((prefix) => normalized.startsWith(prefix));
 };
 
 export const readLastLicenseValidationMs = readLastLicenseValidationSuccessMs;

--- a/src/store/slices/license/licenseMaintenanceActions.js
+++ b/src/store/slices/license/licenseMaintenanceActions.js
@@ -38,8 +38,8 @@ export const createLicenseMaintenanceActions = ({
         if (!lastActiveRaw && !isRealtimeMode) return;
 
         const lastActive = lastActiveRaw ? parseInt(lastActiveRaw, 10) : now;
-        const timeAwayMs = Number.isFinite(lastActive) ? now - lastActive : 0;
-        const timeAwayMinutes = Math.max(timeAwayMs, 0) / (1000 * 60);
+        const timeAwayMs = Number.isFinite(lastActive) ? Math.max(0, now - lastActive) : 0;
+        const timeAwayMinutes = timeAwayMs / (1000 * 60);
 
         // Antes se omitía todo si la app estuvo fuera menos de 3 minutos. En PWA móvil
         // eso deja canales WebSocket dormidos/stale aunque la app esté abierta. Para
@@ -65,7 +65,7 @@ export const createLicenseMaintenanceActions = ({
         }
 
         if (isRealtimeMode && typeof state.recoverRealtimeSecurity === 'function') {
-            await state.recoverRealtimeSecurity(reason);
+            await state.recoverRealtimeSecurity(reason, { timeAwayMs });
             return;
         }
 

--- a/src/store/slices/license/licenseRealtimeActions.js
+++ b/src/store/slices/license/licenseRealtimeActions.js
@@ -10,6 +10,7 @@ import {
 } from '../../../services/licenseRealtime';
 
 import {
+  REALTIME_FORCE_VALIDATE_AFTER_OFFLINE_MS,
   REALTIME_RECOVERY_MIN_INTERVAL_MS
 } from './licenseConstants';
 
@@ -20,6 +21,16 @@ import {
 const waitForRealtimeCleanup = () => new Promise((resolve) => setTimeout(resolve, 200));
 
 let lastRealtimeRecoveryAt = 0;
+
+const normalizeRealtimeReason = (reason = 'manual') => String(reason || 'manual')
+  .trim()
+  .toLowerCase()
+  .replace(/[^a-z0-9_-]+/g, '_') || 'manual';
+
+const getOfflineDurationMs = (metadata = {}) => {
+  const value = Number(metadata.offlineDurationMs ?? metadata.timeAwayMs ?? 0);
+  return Number.isFinite(value) ? Math.max(0, value) : 0;
+};
 
 export const createLicenseRealtimeActions = ({
   set,
@@ -111,16 +122,33 @@ export const createLicenseRealtimeActions = ({
             }
           },
 
-          onPermanentFailure: (message) => {
-            get().reportServerFailure(message, {
-              health: 'down',
-              reason: 'realtime_permanent_failure'
-            });
+          onInitialSubscribed: () => {
+            get().clearServerStatus?.();
+            Logger.log('[Realtime] Canal conectado inicialmente; sin validación remota forzada.');
           },
 
-          onConnectionRestored: () => {
+          onPermanentFailure: async (message, metadata = {}) => {
+            get().reportServerFailure(message, {
+              health: 'down',
+              reason: metadata.reason || 'realtime_permanent_failure'
+            });
+
+            if (metadata.permanent === true) {
+              await get().switchLicenseSyncToPollingFallback?.('realtime_permanent_failure');
+            }
+          },
+
+          onConnectionRestored: async (metadata = {}) => {
             get().clearServerStatus?.();
-            get().runLicenseSyncCheck('realtime_reconnected');
+
+            if (metadata.wasLongDisconnect) {
+              Logger.log('[Realtime] Reconexión larga; se fuerza validación.');
+              await get().runLicenseSyncCheck('realtime_reconnected_long');
+              return;
+            }
+
+            Logger.log('[Realtime] Reconexión corta; se respeta TTL.');
+            await get().runLicenseSyncCheck('realtime_resubscribed_short');
           }
         }
       );
@@ -144,11 +172,14 @@ export const createLicenseRealtimeActions = ({
     }
   },
 
-  recoverRealtimeSecurity: async (reason = 'manual') => {
+  recoverRealtimeSecurity: async (reason = 'manual', metadata = {}) => {
     const state = get();
+    const safeReason = normalizeRealtimeReason(reason);
+    const offlineDurationMs = getOfflineDurationMs(metadata);
+    const wasLongOffline = offlineDurationMs >= REALTIME_FORCE_VALIDATE_AFTER_OFFLINE_MS;
 
     if (state._isRecoveringRealtime) {
-      Logger.log(`[Realtime] Recuperación ya en curso; se omite ${reason}.`);
+      Logger.log(`[Realtime] Recuperación ya en curso; se omite ${safeReason}.`);
       return state.realtimeSubscription;
     }
 
@@ -162,7 +193,7 @@ export const createLicenseRealtimeActions = ({
     }
 
     if (!navigator.onLine) {
-      Logger.warn(`[Realtime] No se recupera canal (${reason}): sin conexión.`);
+      Logger.warn(`[Realtime] No se recupera canal (${safeReason}): sin conexión.`);
       return null;
     }
 
@@ -171,15 +202,32 @@ export const createLicenseRealtimeActions = ({
     const hasActiveChannel = Boolean(state.realtimeSubscription && connectionStatus.isActive);
     const recentlyRecovered = now - lastRealtimeRecoveryAt < REALTIME_RECOVERY_MIN_INTERVAL_MS;
 
-    if (hasActiveChannel && !connectionStatus.isReconnecting && !connectionStatus.isConnecting) {
-      if (recentlyRecovered) {
-        Logger.log(`[Realtime] Canal activo; recuperación omitida por cooldown (${reason}).`);
+    if (connectionStatus.isReconnecting || connectionStatus.isConnecting) {
+      if (wasLongOffline) {
+        Logger.log('[Realtime] Canal reconectando tras pausa larga; se fuerza validación.');
+        await get().runLicenseSyncCheck('realtime_reconnected_long');
+      } else {
+        Logger.log(`[Realtime] Canal reconectando; se evita recuperación duplicada (${safeReason}).`);
+      }
+      return state.realtimeSubscription;
+    }
+
+    if (hasActiveChannel) {
+      if (recentlyRecovered && !wasLongOffline) {
+        Logger.log(`[Realtime] Canal activo; recuperación omitida por cooldown (${safeReason}).`);
         return state.realtimeSubscription;
       }
 
       lastRealtimeRecoveryAt = now;
-      Logger.log(`[Realtime] Canal activo; no se reinicia, solo safety check (${reason}).`);
-      await get().runLicenseSyncCheck(`realtime_probe_${reason}`);
+
+      if (wasLongOffline) {
+        Logger.log('[Realtime] Canal activo tras pausa larga; se fuerza validación.');
+        await get().runLicenseSyncCheck('realtime_reconnected_long');
+        return state.realtimeSubscription;
+      }
+
+      Logger.log('[Realtime] Canal activo; probe no crítico.');
+      await get().runLicenseSyncCheck(`realtime_probe_${safeReason}`);
       return state.realtimeSubscription;
     }
 
@@ -187,16 +235,21 @@ export const createLicenseRealtimeActions = ({
 
     try {
       lastRealtimeRecoveryAt = now;
-      Logger.log(`[Realtime] Recuperando canal privado (${reason}).`);
+      Logger.log('[Realtime] Canal caído; recuperando y validando.');
 
       await get().stopRealtimeSecurity();
       await waitForRealtimeCleanup();
 
       const channel = await get().startRealtimeSecurity();
+      const validationReason = wasLongOffline
+        ? 'realtime_reconnected_long'
+        : `realtime_recover_${safeReason}`;
 
-      // La PWA móvil puede perder eventos mientras estuvo pausada. Al recuperar el
-      // WebSocket forzamos una revalidación inmediata para no depender del polling.
-      await get().runLicenseSyncCheck(`realtime_recover_${reason}`);
+      await get().runLicenseSyncCheck(validationReason);
+
+      if (!channel) {
+        await get().switchLicenseSyncToPollingFallback?.('realtime_recover_failed');
+      }
 
       return channel;
     } catch (error) {

--- a/src/store/slices/license/licenseSyncActions.js
+++ b/src/store/slices/license/licenseSyncActions.js
@@ -114,6 +114,24 @@ export const createLicenseSyncActions = ({
     }
   },
 
+  switchLicenseSyncToPollingFallback: async (reason = 'realtime_failure') => {
+    const state = get();
+
+    if (!state.licenseDetails?.license_key || !state.licenseSyncActive) {
+      return;
+    }
+
+    set({
+      licenseSyncMode: 'hybrid_polling',
+      realtimeSubscription: null
+    });
+
+    restartLicenseSyncTimer(get, 'hybrid_polling');
+
+    const intervalMs = getLicenseSyncIntervalMs(state.licenseDetails, 'hybrid_polling');
+    Logger.warn(`[LicenseSync] Fallback polling activo cada ${Math.round(intervalMs / 60000)}min (${reason}).`);
+  },
+
   startLicenseSync: async () => {
     const state = get();
     const licenseKey = state.licenseDetails?.license_key;
@@ -157,8 +175,7 @@ export const createLicenseSyncActions = ({
       const channel = await get().startRealtimeSecurity();
 
       if (!channel) {
-        set({ licenseSyncMode: 'hybrid_polling' });
-        restartLicenseSyncTimer(get, 'hybrid_polling');
+        await get().switchLicenseSyncToPollingFallback('realtime_start_failed');
       }
     } else {
       await get().stopRealtimeSecurity();
@@ -190,8 +207,7 @@ export const createLicenseSyncActions = ({
       const channel = await get().startRealtimeSecurity();
 
       if (!channel) {
-        set({ licenseSyncMode: 'hybrid_polling' });
-        restartLicenseSyncTimer(get, 'hybrid_polling');
+        await get().switchLicenseSyncToPollingFallback('realtime_refresh_failed');
       }
     } else {
       await get().stopRealtimeSecurity();


### PR DESCRIPTION
## Resumen

Implementa FASE 6H.2 para reducir validaciones remotas innecesarias causadas por resuscripciones/reconexiones realtime, especialmente en PWA/móvil, sin tocar ventas, checkout, caja, reportes, inventario ni RPCs cloud.

## Cambios principales

- Agrega constantes de reconexión adaptativa:
  - `REALTIME_SHORT_RECONNECT_GRACE_MS = 2min`
  - `REALTIME_FORCE_VALIDATE_AFTER_OFFLINE_MS = 15min`
- Mantiene:
  - `PRO_REALTIME_SAFETY_SYNC_INTERVAL_MS = 6h`
  - `PRO_POLLING_SYNC_INTERVAL_MS = 30min`
  - `REALTIME_RECOVERY_MIN_INTERVAL_MS = 5min`
- `licenseRealtime.js` ahora distingue:
  - primera suscripción (`onInitialSubscribed`)
  - reconexión/resuscripción (`onConnectionRestored(metadata)`)
  - desconexión/error/cierre
  - fallo permanente vs aviso transitorio
- Primera conexión realtime ya no llama `onConnectionRestored` ni fuerza validación remota.
- Reconexión corta usa `realtime_resubscribed_short` para respetar TTL y evitar colisión con razones legacy que contienen `realtime_reconnected`.
- Reconexión larga usa `realtime_reconnected_long` y fuerza validación remota.
- Eventos reales realtime siguen usando `realtime_event` y validan inmediatamente.
- `recoverRealtimeSecurity` evita stop/start si el canal está sano; hace probe no crítico en focus/visibility/pageshow.
- Si la app vuelve tras pausa larga mayor a 15min, fuerza validación aun con canal activo.
- Si realtime falla permanentemente, baja a `hybrid_polling` y reinicia timer con intervalo polling.

## Razones críticas

Críticas:
- `realtime_event`
- `realtime_reconnected_long`
- `realtime_recover`
- `realtime_recover_*`
- `license_changed`, `plan_changed`, `device_changed`, `device_revoked`
- `staff_changed`, `staff_invalidated`, `permission_changed`
- `force`, `activation`, `staff_login`, `renewal`

No críticas:
- `realtime_resubscribed_short`
- `realtime_probe_*`
- `online`, `start`, focus/visibility/pageshow sanos

## No tocado

- Checkout / ventas
- `src/hooks/pos/usePosCheckout.js`
- `src/services/sales/*`
- `src/services/salesCloud/*`
- RPCs cloud
- Separación success/attempt ya implementada

## Pruebas sugeridas

- Inicio normal PRO realtime: confirmar log de primera conexión sin validación forzada.
- Focus rápido: confirmar probe no crítico y sin reinicio del canal.
- Microcorte de 30-60s: confirmar reconexión corta y respeto de TTL.
- Offline >15min: confirmar `realtime_reconnected_long` y validación remota.
- Evento crítico: cambiar plan/permisos/staff/dispositivo y confirmar validación inmediata.
- Fallback: simular fallo permanente de realtime y confirmar `hybrid_polling` a 30min.