### PR TITLE
FASE UI.2.2 — Cierre final de prompts nativos y scope menor

### DIFF
--- a/src/components/common/InputPromptModal.jsx
+++ b/src/components/common/InputPromptModal.jsx
@@ -32,7 +32,7 @@ function InputPromptModal({
       return;
     }
 
-    onResolve(trimmedValue || null);
+    onResolve(trimmedValue);
   };
 
   const handleSubmit = (event) => {

--- a/src/components/pos/LayawayModal.css
+++ b/src/components/pos/LayawayModal.css
@@ -387,7 +387,7 @@
     }
 }
 
-.btn-cancel {
+.layaway-modal-overlay .btn-cancel {
     padding: 12px 20px;
     border: 1px solid var(--border-color);
     background-color: transparent;
@@ -396,7 +396,7 @@
     font-weight: 600;
 }
 
-.btn-cancel:hover {
+.layaway-modal-overlay .btn-cancel:hover {
     background-color: var(--light-background);
     color: var(--text-dark);
 }

--- a/src/components/products/batch/hooks/useBatchManagerController.js
+++ b/src/components/products/batch/hooks/useBatchManagerController.js
@@ -13,6 +13,7 @@ import { showMessageModal } from '../../../../services/utils';
 import { loadBatchesForManager } from '../../../../services/inventoryMovement';
 import { useStatsStore } from '../../../../store/useStatsStore';
 import Logger from '../../../../services/Logger';
+import { showInputPromptModal } from '../../../common/InputPromptModal';
 
 /**
  * @param {Object} params
@@ -251,7 +252,15 @@ export function useBatchManagerController({
       actionType = 'Corrección de Descuadre';
     }
 
-    const userNote = window.prompt(confirmMessage + '\n\n(Opcional) Puedes escribir una nota o motivo para archivar este lote:');
+    const userNote = await showInputPromptModal({
+      title: 'Archivar lote',
+      message: `${confirmMessage}\n\nOpcional: puedes escribir una nota o motivo para archivar este lote.`,
+      placeholder: 'Motivo o nota opcional',
+      confirmButtonText: 'Archivar lote',
+      cancelButtonText: 'Cancelar',
+      required: false
+    });
+
     if (userNote === null) return;
 
     const finalNote = userNote.trim() ? ` - Nota del usuario: ${userNote.trim()}` : '';

--- a/src/components/settings/MaintenanceSettings.jsx
+++ b/src/components/settings/MaintenanceSettings.jsx
@@ -8,6 +8,7 @@ import { maintenanceTools } from '../../services/db';
 import { BarChart2, Package, Archive, Database, Download } from 'lucide-react';
 import { evaluator } from '../../services/BackupRiskEvaluator';
 import { showConfirmModal, showMessageModal } from '../../services/utils';
+import { showInputPromptModal } from '../common/InputPromptModal';
 
 const DEFAULT_REBUILD_DAYS = 30;
 
@@ -77,13 +78,18 @@ export default function MaintenanceSettings() {
   };
 
   const handleRebuildStats = async () => {
-    const confirmation = window.prompt(
-      [
+    const confirmation = await showInputPromptModal({
+      title: 'Reconstruir reportes',
+      message: [
         `Esto reconstruirá los reportes de los últimos ${DEFAULT_REBUILD_DAYS} días basándose ÚNICAMENTE en lo que quedó guardado en cada ticket histórico.`,
         'NO actualiza a costos de hoy.',
         'Escribe CONFIRMAR para ejecutar.'
-      ].join('\n\n')
-    );
+      ].join('\n\n'),
+      placeholder: 'CONFIRMAR',
+      confirmButtonText: 'Reconstruir',
+      cancelButtonText: 'Cancelar',
+      required: true
+    });
 
     if (confirmation === null) return;
 


### PR DESCRIPTION
## Resumen

Cierra los últimos pendientes visuales antes de UI.3 sin tocar Supabase, Dexie, ventas cloud, caja, sincronización, outbox, permisos, cálculos monetarios, stock/lotes ni reglas de reportes.

## Cambios

- `MaintenanceSettings.jsx`
  - Reemplaza `window.prompt` de reconstrucción de reportes por `showInputPromptModal(...)`.
  - Mantiene intacta la validación exacta de `CONFIRMAR`, `maintenanceTools.rebuildStats(...)`, `loadStats(false)`, `isProcessing` y mensajes.

- `useBatchManagerController.js`
  - Reemplaza `window.prompt` de archivar lote por `showInputPromptModal(...)`.
  - Mantiene intacta la lógica de `finalNote`, `archivedBatch`, `stock: 0`, `isActive: false`, `isArchived: true`, `status: 'archived'`, notas de merma/descuadre, `productRepository.deleteBatch(...)`, `adjustInventoryValue`, `fetchBatches()` y `refreshData()`.

- `InputPromptModal.jsx`
  - Ajusta la resolución del helper para que cancelar siga devolviendo `null`, pero confirmar un input opcional vacío devuelva `''`.
  - Esto permite archivar lotes sin nota, igual que hacía `window.prompt`.

- `LayawayModal.css`
  - Scopea `.btn-cancel` bajo `.layaway-modal-overlay` para evitar contaminación global entre modales.

## Validación realizada

- Revisé los archivos modificados en la rama y confirmé que ya no contienen `window.prompt` en los dos flujos corregidos.
- Confirmé que `LayawayModal.css` ya no contiene `.btn-cancel {` global; quedó como `.layaway-modal-overlay .btn-cancel`.

## Pendiente local

No pude ejecutar `npm run lint` ni `npm run build` desde el conector de GitHub. También intenté clonar el repo en el entorno, pero no hay resolución DNS hacia GitHub desde el contenedor.

Ejecutar antes de mergear:

```bash
npm run lint
npm run build
```

## Pruebas manuales sugeridas

1. Dashboard → mover pedido a papelera.
2. POS mesas → guardar mesa sin identificador.
3. POS mesas → anular venta rechazada en cocina.
4. Productos/lotes → archivar lote normal.
5. Productos/lotes → archivar lote con stock y nota.
6. Productos/lotes → archivar lote con stock y sin nota.
7. Settings/Mantenimiento → reconstruir reportes escribiendo texto incorrecto.
8. Settings/Mantenimiento → reconstruir reportes escribiendo `CONFIRMAR`.
9. Apartados/Layaway → verificar que botón cancelar no afecta otros modales.
10. Abrir PaymentModal y luego MessageModal → verificar que botones no se contaminan entre modales.