### PR TITLE
FASE UI.7 — Pulido visual final y tokens

### DIFF
--- a/src/components/common/PaymentModal.css
+++ b/src/components/common/PaymentModal.css
@@ -12,13 +12,13 @@
 #payment-modal .payment-label {
   font-weight: 500;
   margin-bottom: var(--spacing-xs);
-  color: var(--text-dark);
+  color: var(--ui-text-strong);
 }
 
 #payment-modal .payment-total {
   font-size: 1.5rem;
   font-weight: 700;
-  color: var(--primary-color);
+  color: var(--ui-color-primary);
   margin-bottom: var(--spacing-md);
 }
 
@@ -27,15 +27,15 @@
   font-size: 1.2rem;
   text-align: center;
   /* Asegura que el input use el fondo correcto del tema */
-  background-color: var(--card-background-color);
-  color: var(--text-dark);
-  border-color: var(--border-color);
+  background-color: var(--ui-bg-surface);
+  color: var(--ui-text-strong);
+  border-color: var(--ui-border-color);
 }
 
 #payment-modal .payment-change {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--success-color);
+  color: var(--ui-text-success);
   text-align: center;
 }
 
@@ -53,9 +53,9 @@
 }
 
 #payment-modal .payment-cancel-button:hover:not(:disabled) {
-  background-color: rgba(239, 68, 68, 0.1);
-  color: var(--error-color);
-  border-color: var(--error-color);
+  background-color: var(--ui-bg-danger-soft);
+  color: var(--ui-text-danger);
+  border-color: var(--ui-color-danger);
 }
 
 #payment-modal .payment-form-group-spaced {
@@ -105,11 +105,11 @@
 #payment-modal .customer-search-results {
   position: absolute;
   width: 100%;
-  background-color: var(--card-background-color);
-  border: 1px solid var(--primary-color);
+  background-color: var(--ui-bg-surface);
+  border: 1px solid var(--ui-color-primary);
   border-top: none;
   border-radius: 0 0 var(--border-radius-sm) var(--border-radius-sm);
-  box-shadow: var(--box-shadow-lg);
+  box-shadow: var(--ui-shadow-lg);
   max-height: 150px;
   overflow-y: auto;
   z-index: 10;
@@ -118,14 +118,15 @@
 #payment-modal .customer-result-item {
   padding: var(--spacing-sm);
   cursor: pointer;
-  color: var(--text-color);
+  color: var(--ui-text);
   font-size: 0.9rem;
-  border-bottom: 1px solid var(--light-background);
+  border-bottom: 1px solid var(--ui-bg-muted);
 }
 
-#payment-modal .customer-result-item:hover {
-  background-color: var(--light-background);
-  color: var(--primary-color);
+#payment-modal .customer-result-item:hover,
+#payment-modal .customer-result-item:focus-visible {
+  background-color: var(--ui-bg-muted);
+  color: var(--ui-color-primary);
 }
 
 #payment-modal .customer-result-item:last-child {
@@ -142,29 +143,37 @@
 #payment-modal .btn-method {
   flex: 1;
   padding: var(--spacing-sm);
-  border: 1px solid var(--border-color);
-  background-color: var(--card-background-color);
-  color: var(--text-light);
+  border: 1px solid var(--ui-border-color);
+  background-color: var(--ui-bg-surface);
+  color: var(--ui-text-muted);
   transition: var(--transition);
 }
 
 #payment-modal .btn-method:hover {
-  background-color: var(--light-background);
-  color: var(--primary-color);
-  border-color: var(--border-color);
+  background-color: var(--ui-bg-muted);
+  color: var(--ui-color-primary);
+  border-color: var(--ui-border-color);
 }
 
 #payment-modal .btn-method.active {
-  background-color: var(--primary-color);
-  color: white;
-  border-color: var(--primary-color);
+  background-color: var(--ui-color-primary);
+  color: var(--ui-text-on-primary);
+  border-color: var(--ui-color-primary);
+}
+
+#payment-modal .btn-method:focus-visible,
+#payment-modal .btn-cash-option:focus-visible,
+#payment-modal .btn-quick-add:focus-visible {
+  outline: none;
+  box-shadow: var(--ui-shadow-focus-primary);
 }
 
 /* --- Botón de añadir rápido --- */
 #payment-modal .btn-quick-add {
   background-color: transparent;
-  color: var(--primary-color);
+  color: var(--ui-color-primary);
   border: none;
+  border-radius: var(--ui-radius-xs);
   padding: var(--spacing-xs) 0;
   margin-top: var(--spacing-xs);
   cursor: pointer;
@@ -179,7 +188,7 @@
 #payment-modal .payment-saldo {
   font-size: 1.25rem;
   font-weight: 600;
-  color: var(--error-color);
+  color: var(--ui-text-danger);
   text-align: center;
 }
 
@@ -195,9 +204,9 @@
 #payment-modal .btn-cash-option {
   padding: 10px 4px;
   /* Usamos variables del tema en lugar de colores fijos */
-  border: 1px solid var(--border-color);
-  background-color: var(--card-background-color);
-  color: var(--text-dark);
+  border: 1px solid var(--ui-border-color);
+  background-color: var(--ui-bg-surface);
+  color: var(--ui-text-strong);
 
   border-radius: var(--border-radius-sm);
   cursor: pointer;
@@ -208,22 +217,22 @@
 }
 
 #payment-modal .btn-cash-option:hover {
-  background-color: var(--light-background);
-  border-color: var(--primary-color);
-  color: var(--primary-color);
+  background-color: var(--ui-bg-muted);
+  border-color: var(--ui-color-primary);
+  color: var(--ui-color-primary);
   transform: translateY(-2px);
-  box-shadow: var(--box-shadow);
+  box-shadow: var(--ui-shadow-sm);
 }
 
 #payment-modal .btn-cash-option:active {
   transform: translateY(0);
-  background-color: var(--light-background);
+  background-color: var(--ui-bg-muted);
 }
 
 #payment-modal .btn-cash-option-exact {
   grid-column: 1 / -1;
-  border-color: var(--success-color);
-  color: var(--success-color);
+  border-color: var(--ui-color-success);
+  color: var(--ui-text-success);
 }
 
 /* * Layout de dos columnas para pantallas grandes 
@@ -257,5 +266,13 @@
 
   #payment-modal .payment-actions {
     margin-top: auto;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  #payment-modal .payment-confirm-button:hover:not(:disabled),
+  #payment-modal .btn-cash-option:hover,
+  #payment-modal .btn-cash-option:active {
+    transform: none;
   }
 }

--- a/src/components/products/batch/BatchFormModal.css
+++ b/src/components/products/batch/BatchFormModal.css
@@ -71,7 +71,7 @@
 
 .btn-close-modal:focus-visible,
 .batch-link-button:focus-visible,
-.caja-payment-toggle:focus-visible-within {
+.caja-payment-toggle:focus-within {
   outline: none;
   box-shadow: var(--ui-shadow-focus-primary);
 }

--- a/src/components/products/batch/BatchFormModal.css
+++ b/src/components/products/batch/BatchFormModal.css
@@ -8,20 +8,21 @@
   flex-direction: column;
   padding: 0 !important;
   overflow: hidden;
-  background-color: var(--card-background-color, #ffffff);
-  border-radius: var(--border-radius, 12px);
-  box-shadow: var(--box-shadow, 0 20px 25px -5px rgba(0, 0, 0, 0.1));
+  background-color: var(--ui-bg-surface);
+  border: 1px solid var(--ui-border-color);
+  border-radius: var(--ui-radius-md);
+  box-shadow: var(--ui-shadow-lg);
 }
 
 /* --- HEADER --- */
 .batch-modal-header {
   padding: 20px 24px;
   flex-shrink: 0;
-  border-bottom: 1px solid var(--border-color, rgba(0,0,0,0.08));
+  border-bottom: 1px solid var(--ui-border-color);
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
-  background-color: var(--card-background-color);
+  background-color: var(--ui-bg-surface);
 }
 
 .batch-modal-header-info {
@@ -34,7 +35,7 @@
   margin: 0;
   font-size: 1.4rem;
   font-weight: 700;
-  color: var(--text-dark);
+  color: var(--ui-text-strong);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -42,30 +43,37 @@
 
 .batch-modal-subtitle {
   margin: 0;
-  color: var(--text-light);
+  color: var(--ui-text-muted);
   font-size: 0.95rem;
 }
 
 .batch-modal-subtitle strong {
-  color: var(--primary-color, #3b82f6);
+  color: var(--ui-color-primary);
 }
 
 .btn-close-modal {
   background: transparent;
   border: none;
-  color: var(--text-light);
+  color: var(--ui-text-muted);
   cursor: pointer;
   padding: 4px;
-  border-radius: 8px;
+  border-radius: var(--ui-radius-sm);
   display: flex;
   align-items: center;
   justify-content: center;
-  transition: all 0.2s ease;
+  transition: background-color var(--ui-transition), color var(--ui-transition), box-shadow var(--ui-transition);
 }
 
 .btn-close-modal:hover {
-  background-color: var(--light-background, #f1f5f9);
-  color: var(--error-color, #ef4444);
+  background-color: var(--ui-bg-muted);
+  color: var(--ui-text-danger);
+}
+
+.btn-close-modal:focus-visible,
+.batch-link-button:focus-visible,
+.caja-payment-toggle:focus-visible-within {
+  outline: none;
+  box-shadow: var(--ui-shadow-focus-primary);
 }
 
 /* --- FORM AREA --- */
@@ -83,7 +91,7 @@
   background: transparent;
 }
 .batch-form-scroll-area::-webkit-scrollbar-thumb {
-  background: var(--border-color, #cbd5e1);
+  background: var(--ui-border-color);
   border-radius: 10px;
 }
 
@@ -104,7 +112,7 @@
   align-items: center;
   gap: 6px;
   font-weight: 600;
-  color: var(--text-dark);
+  color: var(--ui-text-strong);
   margin-bottom: 6px;
 }
 
@@ -112,37 +120,37 @@
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 16px;
-  background-color: var(--light-background, #f8fafc);
+  background-color: var(--ui-bg-muted);
   padding: 16px;
   border-radius: 10px;
-  border: 1px solid var(--border-color, rgba(0,0,0,0.05));
+  border: 1px solid var(--ui-border-color);
 }
 
 [data-theme="dark"] .price-cost-group {
-  background-color: rgba(0,0,0,0.2);
+  background-color: color-mix(in srgb, var(--ui-bg-muted) 72%, transparent);
 }
 
 /* --- TOGGLE CAJA --- */
 .caja-payment-toggle {
   margin-top: 8px;
   padding: 16px;
-  background-color: var(--card-background-color);
-  border: 2px solid var(--border-color, #e2e8f0);
+  background-color: var(--ui-bg-surface);
+  border: 2px solid var(--ui-border-color);
   border-radius: 10px;
   display: flex;
   align-items: center;
   gap: 12px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color var(--ui-transition), border-color var(--ui-transition), box-shadow var(--ui-transition);
 }
 
 .caja-payment-toggle.active {
-  background-color: rgba(59, 130, 246, 0.08); /* Primary color con opacidad */
-  border-color: var(--primary-color, #3b82f6);
+  background-color: var(--ui-bg-info-soft);
+  border-color: var(--ui-color-primary);
 }
 
 .caja-payment-toggle.active label {
-  color: var(--primary-color, #3b82f6);
+  color: var(--ui-color-primary);
   font-weight: 600;
 }
 
@@ -150,7 +158,7 @@
   width: 20px;
   height: 20px;
   cursor: pointer;
-  accent-color: var(--primary-color);
+  accent-color: var(--ui-color-primary);
 }
 
 .caja-payment-toggle label {
@@ -161,15 +169,16 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--text-dark);
+  color: var(--ui-text-strong);
 }
 
 /* --- FOOTER --- */
 .batch-footer-fixed {
   flex-shrink: 0;
   padding: 16px 24px;
-  background-color: var(--card-background-color);
-  border-top: 1px solid var(--border-color, #e2e8f0);
+  padding-bottom: max(16px, var(--safe-area-bottom));
+  background-color: var(--ui-bg-surface);
+  border-top: 1px solid var(--ui-border-color);
 }
 
 .batch-footer-actions {
@@ -188,75 +197,6 @@
   padding: 12px 16px;
   font-weight: 600;
   box-sizing: border-box;
-}
-
-/* --- MEDIA QUERIES (Desktop) --- */
-@media (min-width: 768px) {
-  .batch-form-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 24px;
-  }
-  
-  .batch-footer-actions {
-    flex-direction: row;
-    justify-content: flex-end; /* Alinea el bloque completo a la derecha */
-    gap: 16px;
-    max-width: 620px; /* Evita que los botones se estiren infinitamente */
-    margin-left: auto; /* Empuja el contenedor hacia la derecha */
-  }
-
-  .batch-footer-actions .btn {
-    flex: 1; /* Hace que todos los botones tengan exactamente el mismo ancho */
-    width: auto;
-    white-space: nowrap; /* Evita saltos de línea internos extraños */
-  }
-}/* --- FOOTER --- */
-.batch-footer-fixed {
-  flex-shrink: 0;
-  padding: 16px 24px;
-  background-color: var(--card-background-color);
-  border-top: 1px solid var(--border-color, #e2e8f0);
-}
-
-.batch-footer-actions {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  width: 100%;
-}
-
-.batch-footer-actions .btn {
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 8px;
-  padding: 12px 16px;
-  font-weight: 600;
-  box-sizing: border-box;
-  flex: 1;
-  white-space: nowrap;
-}
-
-/* --- MEDIA QUERIES (Desktop) --- */
-@media (min-width: 768px) {
-  .batch-form-grid {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 24px;
-  }
-  
-  .batch-footer-actions {
-    flex-direction: row;
-    justify-content: flex-end;
-    gap: 16px;
-    max-width: none;
-  }
-
-  .batch-footer-actions .btn {
-    width: auto;
-    flex: 1;
-    max-width: 200px;
-  }
 }
 
 .batch-modal-form {
@@ -290,7 +230,7 @@
 
 .batch-update-price-label {
   margin: 0;
-  color: var(--text-light);
+  color: var(--ui-text-muted);
   font-size: 0.9rem;
   cursor: pointer;
 }
@@ -353,6 +293,7 @@
   color: var(--ui-color-primary);
   background: none;
   border: 0;
+  border-radius: var(--ui-radius-xs);
   font: inherit;
   font-size: 0.82rem;
   text-decoration: underline;
@@ -395,13 +336,32 @@
   grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 
-.batch-footer-fixed {
-  padding-bottom: max(16px, var(--safe-area-bottom));
-}
-
 .batch-update-price-label,
 .caja-payment-toggle label {
   overflow-wrap: anywhere;
+}
+
+/* --- MEDIA QUERIES (Desktop) --- */
+@media (min-width: 768px) {
+  .batch-form-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 24px;
+  }
+
+  .batch-footer-actions {
+    flex-direction: row;
+    justify-content: flex-end;
+    gap: 16px;
+    max-width: 640px;
+    margin-left: auto;
+  }
+
+  .batch-footer-actions .btn {
+    width: auto;
+    flex: 1;
+    max-width: 210px;
+    white-space: nowrap;
+  }
 }
 
 @media (max-width: 640px) {
@@ -434,5 +394,12 @@
   .batch-footer-actions .btn {
     min-height: 44px;
     white-space: normal;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn-close-modal,
+  .caja-payment-toggle {
+    transition: none;
   }
 }

--- a/src/styles/design-tokens.css
+++ b/src/styles/design-tokens.css
@@ -13,6 +13,8 @@
   --ui-bg-surface: var(--card-background-color);
   --ui-bg-muted: var(--light-background);
   --ui-bg-overlay: rgba(15, 23, 42, 0.62);
+  --ui-bg-overlay-strong: rgba(15, 23, 42, 0.72);
+  --ui-bg-overlay-soft: rgba(15, 23, 42, 0.45);
   --ui-bg-success-soft: rgba(16, 185, 129, 0.12);
   --ui-bg-warning-soft: rgba(255, 184, 0, 0.14);
   --ui-bg-danger-soft: rgba(239, 68, 68, 0.12);
@@ -50,9 +52,13 @@
   --ui-radius-sm: var(--border-radius-sm);
   --ui-radius-md: var(--border-radius);
   --ui-radius-lg: 16px;
+  --ui-radius-pill: 999px;
   --ui-shadow-sm: var(--box-shadow);
   --ui-shadow-md: 0 10px 20px -12px rgba(15, 23, 42, 0.28);
   --ui-shadow-lg: var(--box-shadow-lg);
+  --ui-shadow-focus-primary: 0 0 0 3px color-mix(in srgb, var(--ui-color-primary) 28%, transparent);
+  --ui-shadow-focus-danger: 0 0 0 3px color-mix(in srgb, var(--ui-color-danger) 24%, transparent);
+  --ui-shadow-focus-success: 0 0 0 3px color-mix(in srgb, var(--ui-color-success) 24%, transparent);
 
   /* UI motion */
   --ui-transition-fast: 0.16s ease;
@@ -66,5 +72,7 @@
 
 [data-theme="dark"] {
   --ui-bg-overlay: rgba(2, 6, 23, 0.72);
+  --ui-bg-overlay-strong: rgba(2, 6, 23, 0.82);
+  --ui-bg-overlay-soft: rgba(2, 6, 23, 0.56);
   --ui-shadow-md: 0 14px 28px -18px rgba(0, 0, 0, 0.85);
 }

--- a/src/styles/ui-alert.css
+++ b/src/styles/ui-alert.css
@@ -38,23 +38,25 @@
 .ui-alert--info,
 .alert-info,
 .message-info {
-  background-color: rgba(6, 182, 212, 0.1);
-  border-color: rgba(6, 182, 212, 0.22);
-  color: var(--ui-text-strong);
+  background-color: var(--ui-bg-info-soft);
+  border-color: var(--ui-border-info);
+  color: var(--ui-text-info);
 }
 
 .ui-alert--success,
 .alert-success,
 .message-success {
-  background-color: rgba(0, 196, 140, 0.12);
-  border-color: rgba(0, 196, 140, 0.24);
+  background-color: var(--ui-bg-success-soft);
+  border-color: var(--ui-border-success);
+  color: var(--ui-text-success);
 }
 
 .ui-alert--warning,
 .alert-warning,
 .message-warning {
-  background-color: rgba(255, 184, 0, 0.14);
-  border-color: rgba(255, 184, 0, 0.3);
+  background-color: var(--ui-bg-warning-soft);
+  border-color: var(--ui-border-warning);
+  color: var(--ui-text-warning);
 }
 
 .ui-alert--danger,
@@ -62,13 +64,28 @@
 .alert-danger,
 .alert-error,
 .message-error {
-  background-color: rgba(255, 59, 92, 0.11);
-  border-color: rgba(255, 59, 92, 0.24);
+  background-color: var(--ui-bg-danger-soft);
+  border-color: var(--ui-border-danger);
+  color: var(--ui-text-danger);
+}
+
+[data-theme="dark"] .ui-alert--warning,
+[data-theme="dark"] .alert-warning,
+[data-theme="dark"] .message-warning {
+  color: var(--ui-text-warning-on-dark);
+}
+
+[data-theme="dark"] .ui-alert--danger,
+[data-theme="dark"] .ui-alert--error,
+[data-theme="dark"] .alert-danger,
+[data-theme="dark"] .alert-error,
+[data-theme="dark"] .message-error {
+  color: var(--ui-text-danger-on-dark);
 }
 
 .ui-inline-error,
 .validation-message.error {
-  color: var(--ui-color-danger);
+  color: var(--ui-text-danger);
   font-size: 0.88rem;
   font-weight: 700;
 }

--- a/src/styles/ui-badge.css
+++ b/src/styles/ui-badge.css
@@ -4,7 +4,7 @@
   min-height: 24px;
   padding: 0.25rem 0.625rem;
   border: 1px solid transparent;
-  border-radius: 999px;
+  border-radius: var(--ui-radius-pill);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -29,18 +29,18 @@
 .status-badge.success,
 .status-badge.active,
 .badge-success {
-  background-color: rgba(0, 196, 140, 0.14);
-  color: var(--ui-color-success);
-  border-color: rgba(0, 196, 140, 0.24);
+  background-color: var(--ui-bg-success-soft);
+  color: var(--ui-text-success);
+  border-color: var(--ui-border-success);
 }
 
 .ui-badge--warning,
 .status-badge.warning,
 .status-badge.pending,
 .badge-warning {
-  background-color: rgba(255, 184, 0, 0.16);
-  color: #9a6500;
-  border-color: rgba(255, 184, 0, 0.28);
+  background-color: var(--ui-bg-warning-soft);
+  color: var(--ui-text-warning);
+  border-color: var(--ui-border-warning);
 }
 
 .ui-badge--danger,
@@ -50,16 +50,16 @@
 .status-badge.inactive,
 .badge-danger,
 .badge-error {
-  background-color: rgba(255, 59, 92, 0.13);
-  color: var(--ui-color-danger);
-  border-color: rgba(255, 59, 92, 0.24);
+  background-color: var(--ui-bg-danger-soft);
+  color: var(--ui-text-danger);
+  border-color: var(--ui-border-danger);
 }
 
 .ui-badge--info,
 .badge-info {
-  background-color: rgba(6, 182, 212, 0.13);
-  color: var(--ui-color-secondary);
-  border-color: rgba(6, 182, 212, 0.24);
+  background-color: var(--ui-bg-info-soft);
+  color: var(--ui-text-info);
+  border-color: var(--ui-border-info);
 }
 
 .ui-badge--sm {
@@ -72,5 +72,15 @@
 [data-theme="dark"] .status-badge.warning,
 [data-theme="dark"] .status-badge.pending,
 [data-theme="dark"] .badge-warning {
-  color: #ffd166;
+  color: var(--ui-text-warning-on-dark);
+}
+
+[data-theme="dark"] .ui-badge--danger,
+[data-theme="dark"] .ui-badge--error,
+[data-theme="dark"] .status-badge.error,
+[data-theme="dark"] .status-badge.danger,
+[data-theme="dark"] .status-badge.inactive,
+[data-theme="dark"] .badge-danger,
+[data-theme="dark"] .badge-error {
+  color: var(--ui-text-danger-on-dark);
 }

--- a/src/styles/ui-button.css
+++ b/src/styles/ui-button.css
@@ -31,8 +31,8 @@
 
 .ui-button:focus-visible,
 .btn:focus-visible {
-  outline: 3px solid rgba(6, 182, 212, 0.28);
-  outline-offset: 2px;
+  outline: none;
+  box-shadow: var(--ui-shadow-focus-primary);
 }
 
 .ui-button:disabled,
@@ -67,7 +67,7 @@
 .ui-button--secondary,
 .btn-secondary {
   background-color: var(--ui-color-secondary);
-  color: #ffffff;
+  color: var(--ui-text-on-primary);
   border-color: var(--ui-color-secondary);
 }
 
@@ -106,9 +106,9 @@
 .ui-button--danger,
 .btn-delete,
 .btn-danger {
-  background-color: rgba(255, 59, 92, 0.1);
-  color: var(--ui-color-danger);
-  border-color: rgba(255, 59, 92, 0.18);
+  background-color: var(--ui-bg-danger-soft);
+  color: var(--ui-text-danger);
+  border-color: var(--ui-border-danger);
 }
 
 .ui-button--danger:hover:not(:disabled),
@@ -119,16 +119,26 @@
   border-color: var(--ui-color-danger);
 }
 
+.ui-button--danger:focus-visible,
+.btn-delete:focus-visible,
+.btn-danger:focus-visible {
+  box-shadow: var(--ui-shadow-focus-danger);
+}
+
 .ui-button--success {
   background-color: var(--ui-color-success);
-  color: #ffffff;
+  color: var(--ui-text-on-primary);
   border-color: var(--ui-color-success);
 }
 
+.ui-button--success:focus-visible {
+  box-shadow: var(--ui-shadow-focus-success);
+}
+
 .ui-button--warning {
-  background-color: rgba(255, 184, 0, 0.14);
-  color: #9a6500;
-  border-color: rgba(255, 184, 0, 0.3);
+  background-color: var(--ui-bg-warning-soft);
+  color: var(--ui-text-warning);
+  border-color: var(--ui-border-warning);
 }
 
 .ui-button--sm,
@@ -170,7 +180,7 @@
 }
 
 [data-theme="dark"] .ui-button--warning {
-  color: #ffd166;
+  color: var(--ui-text-warning-on-dark);
 }
 
 @media (max-width: 640px) {
@@ -185,5 +195,15 @@
   .btn-icon-small {
     min-width: 40px;
     min-height: 40px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ui-button,
+  .btn,
+  .ui-icon-button,
+  .btn-icon,
+  .btn-icon-small {
+    transition: none;
   }
 }


### PR DESCRIPTION
## Resumen

Implementa una fase de pulido visual estrictamente CSS para UI.7, sin tocar lógica de negocio, servicios, stores, hooks, Supabase, Dexie ni flujos críticos.

### Cambios principales

- Limpieza del duplicado visible en `src/components/products/batch/BatchFormModal.css`.
- Consolidación de un solo bloque final para:
  - `.batch-footer-fixed`
  - `.batch-footer-actions`
  - `.batch-footer-actions .btn`
  - `@media (min-width: 768px)`
  - `@media (max-width: 640px)`
- Reutilización de tokens semánticos en botones, badges, alerts, PaymentModal y BatchFormModal.
- Nuevos tokens de soporte visual:
  - `--ui-bg-overlay-strong`
  - `--ui-bg-overlay-soft`
  - `--ui-shadow-focus-primary`
  - `--ui-shadow-focus-danger`
  - `--ui-shadow-focus-success`
  - `--ui-radius-pill`
- Mejoras de contraste para variantes semánticas en dark mode.
- Focus visible más uniforme en botones, PaymentModal y BatchFormModal.
- Respeto a `prefers-reduced-motion` en botones y modales modificados.

## Archivos modificados

- `src/styles/design-tokens.css`
- `src/styles/ui-button.css`
- `src/styles/ui-alert.css`
- `src/styles/ui-badge.css`
- `src/components/common/PaymentModal.css`
- `src/components/products/batch/BatchFormModal.css`

## Hardcodes conservados intencionalmente

Se mantienen algunos hardcodes ya existentes cuando son parte de tokens base, colores de contraste sobre fondos oscuros, o casos decorativos/legacy fuera del alcance de esta mini fase. No se convirtió todo a ciegas.

## Validaciones

- Búsqueda de `window.confirm`, `window.prompt` y `window.alert`: sin resultados en el repo.
- No se modificó JSX ni lógica funcional.
- No se tocaron flujos de venta, cobro, caja, licencia, staff, sync, outbox, reportes ni repositorios.

Nota: desde el conector no pude ejecutar `npm run lint` ni `npm run build`; quedan como validación local/CI antes de merge.